### PR TITLE
Compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,31 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
@@ -27,9 +48,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "roswaal"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
+ "regex",
  "strum",
  "strum_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,59 +3,75 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
+name = "heck"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
- "memchr",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.2"
+name = "quote"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "regex"
-version = "1.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+ "proc-macro2",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "roswaal"
 version = "0.1.0"
 dependencies = [
- "once_cell",
- "regex",
+ "strum",
+ "strum_macros",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,75 +3,59 @@
 version = 3
 
 [[package]]
-name = "heck"
-version = "0.4.1"
+name = "aho-corasick"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
- "unicode-ident",
+ "memchr",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.36"
+name = "memchr"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
- "proc-macro2",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "roswaal"
 version = "0.1.0"
 dependencies = [
- "strum",
- "strum_macros",
+ "once_cell",
+ "regex",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
-
-[[package]]
-name = "strum"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,6 @@ name = "roswaal"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-strum = "0.26.2"
-strum_macros = "0.26.2"
+once_cell = "1.19.0"
+regex = "1.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "roswaal"
 version = "0.1.0"
 edition = "2021"
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
-once_cell = "1.19.0"
-regex = "1.10.4"
+strum = "0.26.2"
+strum_macros = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+once_cell = "1.19.0"
+regex = "1.10.4"
 strum = "0.26.2"
 strum_macros = "0.26.2"

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -3,9 +3,7 @@ use std::str::FromStr;
 use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
 
-use super::{
-    location::{RoswaalLocationName, RoswaalLocationParsingResult}
-};
+use super::location::{RoswaalLocationName, RoswaalLocationParsingResult};
 
 /// A token of roswaal test syntax.
 ///
@@ -38,23 +36,6 @@ static KNOWN_COMMANDS_REGEX: Lazy<Regex> = Lazy::new(|| {
 
 impl <'a> RoswaalTestSyntaxCommand<'a> {
     fn new(name: &'a str, description: &'a str) -> Self {
-        // let normalized_command = name.roswaal_normalize();
-        // let description = description.trim();
-        // if normalized_command.starts_with("step") {
-        //     return Self::Step
-        // } else if normalized_command.starts_with("setlocation") {
-        //     return Self::SetLocation {
-        //         parse_result: RoswaalLocationName::from_str(description)
-        //     }
-        // } else if normalized_command.starts_with("newtest") {
-        //     return Self::NewTest
-        // } else if normalized_command.starts_with("requirement") {
-        //     return Self::Requirement
-        // } else if normalized_command.starts_with("abstract") {
-        //     return Self::Abstract
-        // } else {
-        //     return Self::UnknownCommand
-        // }
         let captures = match KNOWN_COMMANDS_REGEX.captures(name) {
             Some(c) => c,
             None => return RoswaalTestSyntaxCommand::UnknownCommand

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -175,7 +175,7 @@ mod ast_tests {
 
     #[cfg(test)]
     mod token_tests {
-        use std::{process::Command, str::FromStr};
+        use std::str::FromStr;
 
         use crate::language::location::RoswaalLocationNameParsingError;
 

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -102,7 +102,7 @@ pub struct RoswaalTestSyntax {
 
 impl RoswaalTestSyntax {
     /// Returns an iterator of syntax tokens for each line in the source code.
-    pub fn token_lines(&self) -> impl Iterator<Item = RoswaalTestSyntaxLine> {
+    pub fn lines(&self) -> impl Iterator<Item = RoswaalTestSyntaxLine> {
         self.source_code.lines()
             .enumerate()
             .filter_map(|(i, line)| {
@@ -411,7 +411,7 @@ Requirement 2: Do the other thing
 ";
             let syntax = RoswaalTestSyntax::from(test);
             let tokens = syntax
-                .token_lines()
+                .lines()
                 .collect::<Vec<RoswaalTestSyntaxLine>>();
             assert_eq!(
                 tokens,

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -1,15 +1,15 @@
 use std::str::FromStr;
 
-use once_cell::sync::Lazy;
-use regex::{Regex, RegexBuilder};
-
-use super::location::{RoswaalLocationName, RoswaalLocationParsingResult};
+use super::{
+    location::{RoswaalLocationName, RoswaalLocationParsingResult},
+    normalize::RoswaalNormalize
+};
 
 /// A token of roswaal test syntax.
 ///
 /// Each token represents a line of source code. See `RoswaalTestSyntax`.
 #[derive(Debug, PartialEq, Eq)]
-pub enum RoswaalTestSyntaxCommand<'a> {
+pub enum RoswaalTestSyntaxCommand {
     /// A line denoting a "Step" command without its matching "Requirement"
     /// command.
     Step,
@@ -21,41 +21,30 @@ pub enum RoswaalTestSyntaxCommand<'a> {
     SetLocation { parse_result: RoswaalLocationParsingResult },
     /// A line denoting the "Requirement" command that is to be paired with a
     /// respective step command.
-    Requirement { label: &'a str },
+    Requirement,
     /// A line which has proper command syntax, but the command is not known.
     UnknownCommand
 }
 
-static KNOWN_COMMANDS_REGEX: Lazy<Regex> = Lazy::new(|| {
-    let regex = r"^ *(?:(?<setlocation>set +location)|(?<step>step)|(?<newtest>new +test)|(?<requirement>requirement)|(?<abstract>abstract))(?<label>.*)";
-    RegexBuilder::new(regex)
-        .case_insensitive(true)
-        .build()
-        .expect("Failed to compile known commands regex.")
-});
-
-fn command_with_label<'a>(name: &'a str, description: &'a str) -> (RoswaalTestSyntaxCommand<'a>, &'a str) {
-    let captures = match KNOWN_COMMANDS_REGEX.captures(name) {
-        Some(c) => c,
-        None => return (RoswaalTestSyntaxCommand::UnknownCommand, "")
-    };
-    let label = captures.name("label")
-        .map(|lmatch| lmatch.as_str())
-        .unwrap_or("")
-        .trim();
-    if captures.name("setlocation").is_some() {
-        let command = RoswaalTestSyntaxCommand::SetLocation {
-            parse_result: RoswaalLocationName::from_str(description.trim())
-        };
-        return (command, label)
-    } else if captures.name("step").is_some() {
-        return (RoswaalTestSyntaxCommand::Step, label)
-    } else if captures.name("newtest").is_some() {
-        return (RoswaalTestSyntaxCommand::NewTest, label)
-    } else if captures.name("requirement").is_some() {
-        return (RoswaalTestSyntaxCommand::Requirement { label }, label)
-    } else {
-        return (RoswaalTestSyntaxCommand::Abstract, label)
+impl RoswaalTestSyntaxCommand {
+    fn new(name: &str, description: &str) -> Self {
+        let normalized_command = name.roswaal_normalize();
+        let description = description.trim();
+        if normalized_command.starts_with("step") {
+            return Self::Step
+        } else if normalized_command.starts_with("setlocation") {
+            return Self::SetLocation {
+                parse_result: RoswaalLocationName::from_str(description)
+            }
+        } else if normalized_command.starts_with("newtest") {
+            return Self::NewTest
+        } else if normalized_command.starts_with("requirement") {
+            return Self::Requirement
+        } else if normalized_command.starts_with("abstract") {
+            return Self::Abstract
+        } else {
+            return Self::UnknownCommand
+        }
     }
 }
 
@@ -143,7 +132,7 @@ pub enum RoswaalTestSyntaxLineContent<'a> {
     Command {
         name: &'a str,
         description: &'a str,
-        command: RoswaalTestSyntaxCommand<'a>
+        command: RoswaalTestSyntaxCommand
     }
 }
 
@@ -159,11 +148,10 @@ impl <'a> RoswaalTestSyntaxLineContent<'a> {
                 }
             }
         };
-        let (command, _) = command_with_label(name, description);
         let content = Self::Command {
             name,
             description: description.trim(),
-            command
+            command: RoswaalTestSyntaxCommand::new(name, description)
         };
         Some(content)
     }
@@ -175,7 +163,7 @@ mod ast_tests {
 
     #[cfg(test)]
     mod token_tests {
-        use std::str::FromStr;
+        use std::{process::Command, str::FromStr};
 
         use crate::language::location::RoswaalLocationNameParsingError;
 
@@ -193,22 +181,6 @@ mod ast_tests {
             assert_eq!(
                 content,
                 Some(RoswaalTestSyntaxLineContent::Unknown(source))
-            )
-        }
-
-        #[test]
-        fn test_from_string_returns_unknown_when_words_before_proper_command_names() {
-            let line = "New Requirement: I am a requirement";
-            let content = RoswaalTestSyntaxLineContent::from(line);
-            assert_eq!(
-                content,
-                Some(
-                    RoswaalTestSyntaxLineContent::Command {
-                        name: "New Requirement",
-                        description: "I am a requirement",
-                        command: RoswaalTestSyntaxCommand::UnknownCommand
-                    }
-                )
             )
         }
 
@@ -355,46 +327,23 @@ mod ast_tests {
 
         #[test]
         fn test_from_string_returns_requirement_for_requirement_command() {
-            fn assert_requirement(
-                line: &str,
-                name: &str,
-                requirement_name: &str,
-                description: &str
-            ) {
-                let command = RoswaalTestSyntaxCommand::Requirement {
-                    label: requirement_name
-                };
-                assert_command(line, name, description, command)
+            fn assert_requirement(line: &str, name: &str, description: &str) {
+                assert_command(line, name, description, RoswaalTestSyntaxCommand::Requirement)
             }
 
             assert_requirement(
                 "Requirement 1: Hello world",
                 "Requirement 1",
-                "1",
                 "Hello world"
             );
             assert_requirement(
                 "requirement: test",
                 "requirement",
-                "",
-                "test"
-            );
-            assert_requirement(
-                "requirement1: test",
-                "requirement1",
-                "1",
                 "test"
             );
             assert_requirement(
                 " requirement   4: weird  ",
                 " requirement   4",
-                "4",
-                "weird"
-            );
-            assert_requirement(
-                " requirement God Like: weird  ",
-                " requirement God Like",
-                "God Like",
                 "weird"
             )
         }
@@ -539,9 +488,7 @@ Requirement 2: Do the other thing
                         content: RoswaalTestSyntaxLineContent::Command {
                             name: "Requirement 1",
                             description: "Do the thing",
-                            command: RoswaalTestSyntaxCommand::Requirement {
-                                label: "1"
-                            }
+                            command: RoswaalTestSyntaxCommand::Requirement
                         }
                     },
                     RoswaalTestSyntaxLine {
@@ -549,9 +496,7 @@ Requirement 2: Do the other thing
                         content: RoswaalTestSyntaxLineContent::Command {
                             name: "Requirement 2",
                             description: "Do the other thing",
-                            command: RoswaalTestSyntaxCommand::Requirement {
-                                label: "2"
-                            }
+                            command: RoswaalTestSyntaxCommand::Requirement
                         }
                     }
                 )

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -112,6 +112,18 @@ impl RoswaalTestSyntax {
                     })
             })
     }
+
+    /// Returns the last line number of this syntax.
+    ///
+    /// If the syntax is empty, line 1 is returned.
+    pub fn last_line_number(&self) -> u32 {
+        let line_count = self.source_code.lines().count();
+        return if line_count == 0 {
+            1
+        } else {
+            line_count as u32
+        }
+    }
 }
 
 impl From<&str> for RoswaalTestSyntax {
@@ -305,6 +317,31 @@ mod ast_tests {
         use crate::language::ast::{ast_tests::RoswaalLocationName, RoswaalTestSyntaxLine};
 
         use super::{RoswaalTestSyntax, RoswaalTestSyntaxToken};
+
+        #[test]
+        fn test_last_line_number_returns_1_when_empty() {
+            let syntax = RoswaalTestSyntax::from("");
+            assert_eq!(syntax.last_line_number(), 1)
+        }
+
+        #[test]
+        fn test_last_line_number_returns_1_when_single_line() {
+            let syntax = RoswaalTestSyntax::from("hello");
+            assert_eq!(syntax.last_line_number(), 1)
+        }
+
+        #[test]
+        fn test_last_line_number_returns_1_number_of_lines_in_code() {
+            let test = "\
+New Test: I am a test
+Step 1: Piccolo was the first to try
+Requirement 1: Have piccolo fight Android 17 and 18 all at once
+Step 2: And the first to die
+Requirement 2: Make sure that \"even Krillin\" can't be stopped by the dreadful duo
+";
+            let syntax = RoswaalTestSyntax::from(test);
+            assert_eq!(syntax.last_line_number(), 5)
+        }
 
         #[test]
         fn test_token_lines_iterator() {

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -76,11 +76,11 @@ impl RoswaalTestSyntaxCommand {
 /// Requirement 1: I am a requirement that matches step 1.
 /// Requirement 2: I am a requirement that is paired with step 2.
 /// ```
-pub struct RoswaalTestSyntax {
-    source_code: String
+pub struct RoswaalTestSyntax<'a> {
+    source_code: &'a str
 }
 
-impl RoswaalTestSyntax {
+impl <'a> RoswaalTestSyntax<'a> {
     /// Returns an iterator of syntax tokens for each line in the source code.
     pub fn lines(&self) -> impl Iterator<Item = RoswaalTestSyntaxLine> {
         self.source_code.lines()
@@ -109,9 +109,9 @@ impl RoswaalTestSyntax {
     }
 }
 
-impl From<&str> for RoswaalTestSyntax {
-    fn from(source_code: &str) -> Self {
-        Self { source_code: source_code.to_string() }
+impl <'a> From<&'a str> for RoswaalTestSyntax<'a> {
+    fn from(source_code: &'a str) -> Self {
+        Self { source_code }
     }
 }
 

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -11,7 +11,6 @@ pub enum RoswaalCompilationErrorCode {
     NoTestName,
     NoTestSteps,
     NoCommandDescription { command_name: String },
-    MissingStep { requirement_name: String },
     InvalidLocationName(String),
     InvalidCommandName(String),
     DuplicateTestName(String),
@@ -108,15 +107,6 @@ impl RoswaalCompile for RoswaalTest {
                                 code: RoswaalCompilationErrorCode::InvalidCommandName(
                                     name.to_string()
                                 )
-                            };
-                            errors.push(error)
-                        },
-                        RoswaalTestSyntaxCommand::Requirement { label: name } => {
-                            let error = RoswaalCompilationError {
-                                line_number,
-                                code: RoswaalCompilationErrorCode::MissingStep {
-                                    requirement_name: name.to_string()
-                                }
                             };
                             errors.push(error)
                         },
@@ -364,22 +354,6 @@ Set Location: world
             code: RoswaalCompilationErrorCode::InvalidLocationName("world".to_string())
         };
         assert_contains_compile_error(&result, &error);
-    }
-
-    #[test]
-    fn test_parse_returns_no_step_for_requirement_when_requirement_has_no_accompanying_step() {
-        let test = "\
-New test: the thing
-Requirement 1: hello
-";
-        let result = RoswaalTest::compile(test, RoswaalCompileContext::empty());
-        let error = RoswaalCompilationError {
-            line_number: 2,
-            code: RoswaalCompilationErrorCode::MissingStep {
-                requirement_name: "1".to_string()
-            }
-        };
-        assert_contains_compile_error(&result, &error)
     }
 
     fn assert_contains_compile_error(

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -57,7 +57,7 @@ impl RoswaalCompile for RoswaalTest {
     ) -> Result<Self, Vec<RoswaalCompilationError>> {
         let mut errors: Vec<RoswaalCompilationError> = Vec::new();
         let mut has_test_line = false;
-        for line in syntax.token_lines() {
+        for line in syntax.lines() {
             let line_number = line.line_number();
             match line.token() {
                 RoswaalTestSyntaxToken::NewTest { command_name: _, test_name: name } => {
@@ -339,7 +339,7 @@ Set Location: world
 ";
         let result = RoswaalTest::compile(
             test,
-            RoswaalCompileContext { location_names, test_names: vec![] }
+            RoswaalCompileContext::new(location_names, vec![])
         );
         let error = RoswaalCompilationError {
             line_number: 2,

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -14,7 +14,8 @@ pub enum RoswaalCompilationErrorCode {
     NoLocationSpecified,
     InvalidLocationName(String),
     InvalidCommandName(String),
-    DuplicateTestName(String)
+    DuplicateTestName(String),
+    TestNameAlreadyDeclared
 }
 
 pub struct RoswaalCompileContext {
@@ -66,6 +67,13 @@ impl RoswaalCompile for RoswaalTest {
                         let error = RoswaalCompilationError {
                             line_number,
                             code: RoswaalCompilationErrorCode::DuplicateTestName(name.to_string())
+                        };
+                        errors.push(error);
+                    }
+                    if has_test_line {
+                        let error = RoswaalCompilationError {
+                            line_number,
+                            code: RoswaalCompilationErrorCode::TestNameAlreadyDeclared
                         };
                         errors.push(error);
                     }
@@ -256,6 +264,20 @@ lsjkhadjkhasdfjkhasdjkfhkjsd
         let error = RoswaalCompilationError {
             line_number: 1,
             code: RoswaalCompilationErrorCode::DuplicateTestName(test_name.to_string())
+        };
+        assert_contains_compile_error(&result, &error)
+    }
+
+    #[test]
+    fn test_parse_returns_test_name_declared_when_2_new_test_commands() {
+        let test = "\
+New test: Test 1
+New Test: Test 2
+";
+        let result = RoswaalTest::compile(test, RoswaalCompileContext::empty());
+        let error = RoswaalCompilationError {
+            line_number: 2,
+            code: RoswaalCompilationErrorCode::TestNameAlreadyDeclared
         };
         assert_contains_compile_error(&result, &error)
     }

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -36,7 +36,7 @@ impl RoswaalCompile for RoswaalTest {
         let has_test_name = token_lines
             .next()
             .map(|line| {
-                let token = line.token;
+                let token = line.token();
                 is_case!(token, RoswaalTestSyntaxToken::NewTest)
             })
             .unwrap_or(false);
@@ -57,10 +57,10 @@ impl RoswaalCompile for RoswaalTest {
                 return Err(error)
             }
         };
-        match step_line.token {
+        match step_line.token() {
             RoswaalTestSyntaxToken::Step { description: _ } => {
                 let error = RoswaalCompilationError {
-                    line_number: step_line.line_number,
+                    line_number: step_line.line_number(),
                     code: RoswaalCompilationErrorCode::NoStepDescription {
                         step_name: "Step 1".to_string()
                     }
@@ -69,14 +69,14 @@ impl RoswaalCompile for RoswaalTest {
             },
             RoswaalTestSyntaxToken::SetLocation { parse_result: _ } => {
                 let error = RoswaalCompilationError {
-                    line_number: step_line.line_number,
+                    line_number: step_line.line_number(),
                     code: RoswaalCompilationErrorCode::NoLocationSpecified
                 };
                 return Err(error)
             },
             RoswaalTestSyntaxToken::UnknownCommand { name, description: _ } => {
                 let error = RoswaalCompilationError {
-                    line_number: step_line.line_number,
+                    line_number: step_line.line_number(),
                     code: RoswaalCompilationErrorCode::InvalidCommandName(
                         name.to_string()
                     )
@@ -85,7 +85,7 @@ impl RoswaalCompile for RoswaalTest {
             }
             _ => {
                 let error = RoswaalCompilationError {
-                    line_number: step_line.line_number,
+                    line_number: step_line.line_number(),
                     code: RoswaalCompilationErrorCode::NoTestSteps
                 };
                 return Err(error)

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -58,11 +58,11 @@ impl RoswaalCompile for RoswaalTest {
             }
         };
         match step_line.token() {
-            RoswaalTestSyntaxToken::Step { description: _ } => {
+            RoswaalTestSyntaxToken::Step { name, description: _ } => {
                 let error = RoswaalCompilationError {
                     line_number: step_line.line_number(),
                     code: RoswaalCompilationErrorCode::NoStepDescription {
-                        step_name: "Step 1".to_string()
+                        step_name: name.to_string()
                     }
                 };
                 return Err(error)

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -10,8 +10,7 @@ pub struct RoswaalCompilationError {
 pub enum RoswaalCompilationErrorCode {
     NoTestName,
     NoTestSteps,
-    NoStepDescription { step_name: String },
-    NoLocationSpecified,
+    NoCommandDescription { command_name: String },
     InvalidLocationName(String),
     InvalidCommandName(String),
     DuplicateTestName(String),
@@ -81,8 +80,8 @@ impl RoswaalCompile for RoswaalTest {
                 RoswaalTestSyntaxToken::Step { name, description: _ } => {
                     let error = RoswaalCompilationError {
                         line_number,
-                        code: RoswaalCompilationErrorCode::NoStepDescription {
-                            step_name: name.to_string()
+                        code: RoswaalCompilationErrorCode::NoCommandDescription {
+                            command_name: name.to_string()
                         }
                     };
                     errors.push(error);
@@ -97,7 +96,9 @@ impl RoswaalCompile for RoswaalTest {
                         },
                         Err(_) => RoswaalCompilationError {
                             line_number,
-                            code: RoswaalCompilationErrorCode::NoLocationSpecified
+                            code: RoswaalCompilationErrorCode::NoCommandDescription {
+                                command_name: "Set Location".to_string()
+                            }
                         }
                     };
                     errors.push(err);
@@ -306,8 +307,8 @@ Step 1:
         let result = RoswaalTest::compile(test, RoswaalCompileContext::empty());
         let error = RoswaalCompilationError {
             line_number: 2,
-            code: RoswaalCompilationErrorCode::NoStepDescription {
-                step_name: "Step 1".to_string()
+            code: RoswaalCompilationErrorCode::NoCommandDescription {
+                command_name: "Step 1".to_string()
             }
         };
         assert_contains_compile_error(&result, &error);
@@ -322,7 +323,9 @@ Set Location:
         let result = RoswaalTest::compile(test, RoswaalCompileContext::empty());
         let error = RoswaalCompilationError {
             line_number: 2,
-            code: RoswaalCompilationErrorCode::NoLocationSpecified
+            code: RoswaalCompilationErrorCode::NoCommandDescription {
+                command_name: "Set Location".to_string()
+            }
         };
         assert_contains_compile_error(&result, &error);
     }

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -216,7 +216,6 @@ impl RoswaalCompileContext {
         }
         let mut did_match = false;
         if let Some(requirement_info) = self.matchable_requirements.get_mut(&label_key) {
-            if requirement_info.did_match { return }
             let command = RoswaalTestCommand::Step {
                 name: description.to_string(),
                 requirement: requirement_info.description.clone()
@@ -248,7 +247,6 @@ impl RoswaalCompileContext {
         }
         let mut did_match = false;
         if let Some(step_info) = self.matchable_steps.get_mut(&label_key) {
-            if step_info.did_match { return }
             let command = RoswaalTestCommand::Step {
                 name: step_info.description.clone(),
                 requirement: description.to_string()

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -179,10 +179,10 @@ impl RoswaalCompile for RoswaalTest {
                             );
                             ctx.append_error(line_number, code);
                         },
-                        RoswaalTestSyntaxCommand::Step => {
+                        RoswaalTestSyntaxCommand::Step { label: _ } => {
                             ctx.append_step(line_number, name, description);
                         },
-                        RoswaalTestSyntaxCommand::Requirement => {
+                        RoswaalTestSyntaxCommand::Requirement { label: _ } => {
                             ctx.append_requirment(line_number, name, description);
                         },
                         _ => {}

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -159,7 +159,7 @@ impl RoswaalCompile for RoswaalTest {
                 requirement_name: requirement_info.name.clone(),
                 requirement_description: requirement_info.description.clone()
             };
-            errors.push(RoswaalCompilationError { line_number: requirement_info.line_number, code })
+            errors.append_error(requirement_info.line_number, code);
         }
 
         ctx.errors.append(&mut errors);

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -1,6 +1,6 @@
 use crate::is_case;
 
-use super::{ast::{RoswaalTestSyntax, RoswaalTestSyntaxToken}, test::RoswaalTest};
+use super::{ast::{RoswaalTestSyntax, RoswaalTestSyntaxToken}, location::RoswaalLocationName, test::RoswaalTest};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct RoswaalCompilationError {
@@ -14,93 +14,113 @@ pub enum RoswaalCompilationErrorCode {
     NoTestSteps,
     NoStepDescription { step_name: String },
     NoLocationSpecified,
+    InvalidLocationName(String),
     InvalidCommandName(String)
 }
 
 /// A trait for self-initializing by compiling roswaal test syntax.
 pub trait RoswaalCompile: Sized {
     fn compile_syntax(
-        syntax: RoswaalTestSyntax
+        syntax: RoswaalTestSyntax,
+        locations: Vec<RoswaalLocationName>
     ) -> Result<Self, RoswaalCompilationError>;
 
     fn compile(
-        source_code: &str
+        source_code: &str,
+        locations: Vec<RoswaalLocationName>
     ) -> Result<Self, RoswaalCompilationError> {
-        Self::compile_syntax(RoswaalTestSyntax::from(source_code))
+        Self::compile_syntax(RoswaalTestSyntax::from(source_code), locations)
     }
 }
 
 impl RoswaalCompile for RoswaalTest {
-    fn compile_syntax(syntax: RoswaalTestSyntax) -> Result<Self, RoswaalCompilationError> {
-        let mut token_lines = syntax.token_lines();
-        let has_test_name = token_lines
-            .next()
-            .map(|line| {
-                let token = line.token();
-                is_case!(token, RoswaalTestSyntaxToken::NewTest)
-            })
-            .unwrap_or(false);
-        if !has_test_name {
-            let error = RoswaalCompilationError {
-                line_number: 1,
-                code: RoswaalCompilationErrorCode::NoTestName
-            };
-            return Err(error);
+    fn compile_syntax(
+        syntax: RoswaalTestSyntax,
+        locations: Vec<RoswaalLocationName>
+    ) -> Result<Self, RoswaalCompilationError> {
+        let mut has_test_line = false;
+        for line in syntax.token_lines() {
+            let line_number = line.line_number();
+            match line.token() {
+                RoswaalTestSyntaxToken::NewTest { name: _ } => {
+                    has_test_line = true
+                },
+                RoswaalTestSyntaxToken::Step { name, description: _ } => {
+                    let error = RoswaalCompilationError {
+                        line_number,
+                        code: RoswaalCompilationErrorCode::NoStepDescription {
+                            step_name: name.to_string()
+                        }
+                    };
+                    return Err(error);
+                },
+                RoswaalTestSyntaxToken::SetLocation { parse_result } => {
+                    return match parse_result {
+                        Ok(name) => Err(
+                            RoswaalCompilationError {
+                                line_number,
+                                code: RoswaalCompilationErrorCode::InvalidLocationName(
+                                    name.name().to_string()
+                                )
+                            }
+                        ),
+                        Err(_) => Err(
+                            RoswaalCompilationError {
+                                line_number,
+                                code: RoswaalCompilationErrorCode::NoLocationSpecified
+                            }
+                        )
+                    };
+                },
+                RoswaalTestSyntaxToken::UnknownCommand { name, description: _ } => {
+                    let error = RoswaalCompilationError {
+                        line_number,
+                        code: RoswaalCompilationErrorCode::InvalidCommandName(
+                            name.to_string()
+                        )
+                    };
+                    return Err(error)
+                },
+                RoswaalTestSyntaxToken::Unknown { source } => {
+                    let error = RoswaalCompilationError {
+                        line_number,
+                        code: RoswaalCompilationErrorCode::InvalidCommandName(
+                            source.to_string()
+                        )
+                    };
+                    return Err(error)
+                },
+                _ => {}
+            }
         }
-        let step_line = match token_lines.next() {
-            Some(line) => line,
-            None => {
-                let error = RoswaalCompilationError {
-                    line_number: 1,
-                    code: RoswaalCompilationErrorCode::NoTestSteps
-                };
-                return Err(error)
-            }
-        };
-        match step_line.token() {
-            RoswaalTestSyntaxToken::Step { name, description: _ } => {
-                let error = RoswaalCompilationError {
-                    line_number: step_line.line_number(),
-                    code: RoswaalCompilationErrorCode::NoStepDescription {
-                        step_name: name.to_string()
-                    }
-                };
-                return Err(error)
-            },
-            RoswaalTestSyntaxToken::SetLocation { parse_result: _ } => {
-                let error = RoswaalCompilationError {
-                    line_number: step_line.line_number(),
-                    code: RoswaalCompilationErrorCode::NoLocationSpecified
-                };
-                return Err(error)
-            },
-            RoswaalTestSyntaxToken::UnknownCommand { name, description: _ } => {
-                let error = RoswaalCompilationError {
-                    line_number: step_line.line_number(),
-                    code: RoswaalCompilationErrorCode::InvalidCommandName(
-                        name.to_string()
-                    )
-                };
-                return Err(error)
-            }
-            _ => {
-                let error = RoswaalCompilationError {
-                    line_number: step_line.line_number(),
-                    code: RoswaalCompilationErrorCode::NoTestSteps
-                };
-                return Err(error)
-            }
+        if !has_test_line {
+            return Err(
+                RoswaalCompilationError {
+                    line_number: syntax.last_line_number(),
+                    code: RoswaalCompilationErrorCode::NoTestName
+                }
+            )
         }
+        Err(
+            RoswaalCompilationError {
+                line_number: syntax.last_line_number(),
+                code: RoswaalCompilationErrorCode::NoTestSteps
+            }
+        )
     }
 }
 
 #[cfg(test)]
 mod compiler_tests {
+    use std::str::FromStr;
+
+    use crate::language::location::RoswaalLocationName;
+
     use super::*;
 
     #[test]
     fn test_parse_returns_no_name_for_empty_string() {
-        let result = RoswaalTest::compile("");
+        let result = RoswaalTest::compile("", vec![]);
         let error = RoswaalCompilationError {
             line_number: 1,
             code: RoswaalCompilationErrorCode::NoTestName
@@ -109,18 +129,32 @@ mod compiler_tests {
     }
 
     #[test]
-    fn test_parse_returns_no_name_for_random_string() {
-        let result = RoswaalTest::compile("jkashdkjashdkjahsd ehiuh3ui2geuyg23urg");
+    fn test_parse_returns_no_name_for_random_multiline_string() {
+        let test = "\n\n\n\n";
+        let result = RoswaalTest::compile(test, vec![]);
+        let error = RoswaalCompilationError {
+            line_number: 4,
+            code: RoswaalCompilationErrorCode::NoTestName
+        };
+        assert_eq!(result, Err(error))
+    }
+
+    #[test]
+    fn test_parse_returns_unknown_command_for_random_string() {
+        let code = "jkashdkjashdkjahsd ehiuh3ui2geuyg23urg";
+        let result = RoswaalTest::compile(code, vec![]);
         let error = RoswaalCompilationError {
             line_number: 1,
-            code: RoswaalCompilationErrorCode::NoTestName
+            code: RoswaalCompilationErrorCode::InvalidCommandName(
+                code.to_string()
+            )
         };
         assert_eq!(result, Err(error))
     }
 
     #[test]
     fn test_parse_returns_no_steps_when_name_formatted_correctly_uppercase() {
-        let result = RoswaalTest::compile("New Test: Hello world");
+        let result = RoswaalTest::compile("New Test: Hello world", vec![]);
         let error = RoswaalCompilationError {
             line_number: 1,
             code: RoswaalCompilationErrorCode::NoTestSteps
@@ -130,7 +164,7 @@ mod compiler_tests {
 
     #[test]
     fn test_parse_returns_no_steps_when_name_formatted_correctly_lowercase() {
-        let result = RoswaalTest::compile("new test: Hello world");
+        let result = RoswaalTest::compile("new test: Hello world", vec![]);
         let error = RoswaalCompilationError {
             line_number: 1,
             code: RoswaalCompilationErrorCode::NoTestSteps
@@ -139,16 +173,29 @@ mod compiler_tests {
     }
 
     #[test]
-    fn test_parse_returns_no_steps_when_step_line_is_random_string() {
+    fn test_parse_returns_invalid_command_name_when_step_line_is_random_string() {
         let test = "\
 new test: Hello world
 lsjkhadjkhasdfjkhasdjkfhkjsd
 ";
         let error = RoswaalCompilationError {
             line_number: 2,
+            code: RoswaalCompilationErrorCode::InvalidCommandName(
+                "lsjkhadjkhasdfjkhasdjkfhkjsd".to_string()
+            )
+        };
+        let result = RoswaalTest::compile(test, vec![]);
+        assert_eq!(result, Err(error))
+    }
+
+    #[test]
+    fn test_parse_returns_no_steps_when_mutliple_lines_before_new_test() {
+        let test = "\n\n\n\nnew test: Hello world";
+        let error = RoswaalCompilationError {
+            line_number: 5,
             code: RoswaalCompilationErrorCode::NoTestSteps
         };
-        let result = RoswaalTest::compile(test);
+        let result = RoswaalTest::compile(test, vec![]);
         assert_eq!(result, Err(error))
     }
 
@@ -158,7 +205,7 @@ lsjkhadjkhasdfjkhasdjkfhkjsd
 new test: Hello world
 passo 1: mamma mia
 ";
-        let result = RoswaalTest::compile(test);
+        let result = RoswaalTest::compile(test, vec![]);
         let step_name = String::from("passo 1");
         let error = RoswaalCompilationError {
             line_number: 2,
@@ -173,7 +220,7 @@ passo 1: mamma mia
 New Test: Hello wordl
 Step 1:
 ";
-        let result = RoswaalTest::compile(test);
+        let result = RoswaalTest::compile(test, vec![]);
         let error = RoswaalCompilationError {
             line_number: 2,
             code: RoswaalCompilationErrorCode::NoStepDescription {
@@ -189,10 +236,25 @@ Step 1:
 New test: This is an acceptance test
 Set Location:
 ";
-        let result = RoswaalTest::compile(test);
+        let result = RoswaalTest::compile(test, vec![]);
         let error = RoswaalCompilationError {
             line_number: 2,
             code: RoswaalCompilationErrorCode::NoLocationSpecified
+        };
+        assert_eq!(result, Err(error))
+    }
+
+    #[test]
+    fn test_parse_returns_invalid_location_when_location_name_is_not_in_locations_list() {
+        let locations = vec!(RoswaalLocationName::from_str("Hello").unwrap());
+        let test = "\
+New test: This is an acceptance test
+Set Location: world
+";
+        let result = RoswaalTest::compile(test, locations);
+        let error = RoswaalCompilationError {
+            line_number: 2,
+            code: RoswaalCompilationErrorCode::InvalidLocationName("world".to_string())
         };
         assert_eq!(result, Err(error))
     }

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -60,7 +60,7 @@ impl RoswaalCompile for RoswaalTest {
         for line in syntax.token_lines() {
             let line_number = line.line_number();
             match line.token() {
-                RoswaalTestSyntaxToken::NewTest { name } => {
+                RoswaalTestSyntaxToken::NewTest { command_name: _, test_name: name } => {
                     has_test_line = true;
                     if ctx.test_names.contains(&name.to_string()) {
                         let error = RoswaalCompilationError {
@@ -86,7 +86,7 @@ impl RoswaalCompile for RoswaalTest {
                     };
                     errors.push(error);
                 },
-                RoswaalTestSyntaxToken::SetLocation { parse_result } => {
+                RoswaalTestSyntaxToken::SetLocation { command_name, parse_result } => {
                     let err = match parse_result {
                         Ok(name) => RoswaalCompilationError {
                             line_number,
@@ -97,7 +97,7 @@ impl RoswaalCompile for RoswaalTest {
                         Err(_) => RoswaalCompilationError {
                             line_number,
                             code: RoswaalCompilationErrorCode::NoCommandDescription {
-                                command_name: "Set Location".to_string()
+                                command_name: command_name.to_string()
                             }
                         }
                     };

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -11,6 +11,7 @@ pub enum RoswaalCompilationErrorCode {
     NoTestName,
     NoTestSteps,
     NoCommandDescription { command_name: String },
+    MissingStep { requirement_name: String },
     InvalidLocationName(String),
     InvalidCommandName(String),
     DuplicateTestName(String),
@@ -107,6 +108,15 @@ impl RoswaalCompile for RoswaalTest {
                                 code: RoswaalCompilationErrorCode::InvalidCommandName(
                                     name.to_string()
                                 )
+                            };
+                            errors.push(error)
+                        },
+                        RoswaalTestSyntaxCommand::Requirement { label: name } => {
+                            let error = RoswaalCompilationError {
+                                line_number,
+                                code: RoswaalCompilationErrorCode::MissingStep {
+                                    requirement_name: name.to_string()
+                                }
                             };
                             errors.push(error)
                         },
@@ -354,6 +364,22 @@ Set Location: world
             code: RoswaalCompilationErrorCode::InvalidLocationName("world".to_string())
         };
         assert_contains_compile_error(&result, &error);
+    }
+
+    #[test]
+    fn test_parse_returns_no_step_for_requirement_when_requirement_has_no_accompanying_step() {
+        let test = "\
+New test: the thing
+Requirement 1: hello
+";
+        let result = RoswaalTest::compile(test, RoswaalCompileContext::empty());
+        let error = RoswaalCompilationError {
+            line_number: 2,
+            code: RoswaalCompilationErrorCode::MissingStep {
+                requirement_name: "1".to_string()
+            }
+        };
+        assert_contains_compile_error(&result, &error)
     }
 
     fn assert_contains_compile_error(

--- a/src/language/location.rs
+++ b/src/language/location.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use super::normalize::RoswaalNormalize;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum RoswaalLocationNameParsingError {
     Empty
 }
@@ -16,7 +16,7 @@ pub type RoswaalLocationParsingResult = Result<
 ///
 /// This type contains helpers for matching the name against a query, and
 /// for formatting the name in different contexts.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RoswaalLocationName {
     raw_value: String
 }

--- a/src/language/location.rs
+++ b/src/language/location.rs
@@ -45,8 +45,8 @@ impl RoswaalLocationName {
     /// let name = RoswaalLocationName::from_str("hello world").unwrap();
     /// assert!(name.matches("  Hello  World  "))
     /// ```
-    pub fn matches(&self, str: &str) -> bool {
-        self.name().roswaal_normalize() == str.roswaal_normalize()
+    pub fn matches(&self, other: &Self) -> bool {
+        self.name().roswaal_normalize() == other.name().roswaal_normalize()
     }
 }
 
@@ -67,26 +67,20 @@ mod roswaal_location_tests {
     }
 
     #[test]
-    fn test_matches_returns_false_when_empty_string() {
-        let name = RoswaalLocationName::from_str("hello world").unwrap();
-        assert!(!name.matches(""))
-    }
-
-    #[test]
     fn test_matches_returns_true_when_exact_same_name() {
         let name = RoswaalLocationName::from_str("hello world").unwrap();
-        assert!(name.matches("hello world"))
+        assert!(name.matches(&"hello world".parse().unwrap()))
     }
 
     #[test]
     fn test_matches_returns_true_when_same_name_but_uppercased() {
         let name = RoswaalLocationName::from_str("hello world").unwrap();
-        assert!(name.matches("Hello World"))
+        assert!(name.matches(&"Hello World".parse().unwrap()))
     }
 
     #[test]
     fn test_matches_returns_true_when_same_name_but_different_white_spacing_and_uppercased() {
         let name = RoswaalLocationName::from_str("hello world").unwrap();
-        assert!(name.matches("\t  Hello   World\t  "))
+        assert!(name.matches(&"\t  Hello   World\t  ".parse().unwrap()))
     }
 }

--- a/src/language/test.rs
+++ b/src/language/test.rs
@@ -12,7 +12,7 @@ impl RoswaalTest {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RoswaalTestCommand {
     Step { name: String, requirement: String },
     SetLocation { location_name: RoswaalLocationName }

--- a/src/language/test.rs
+++ b/src/language/test.rs
@@ -3,12 +3,17 @@ use super::location::RoswaalLocationName;
 #[derive(Debug, PartialEq, Eq)]
 pub struct RoswaalTest {
     name: String,
+    description: Option<String>,
     commands: Vec<RoswaalTestCommand>
 }
 
 impl RoswaalTest {
-    pub fn new(name: String, commands: Vec<RoswaalTestCommand>) -> Self {
-        Self { name, commands }
+    pub fn new(
+        name: String,
+        description: Option<String>,
+        commands: Vec<RoswaalTestCommand>
+    ) -> Self {
+        Self { name, description, commands }
     }
 }
 

--- a/src/language/test.rs
+++ b/src/language/test.rs
@@ -1,2 +1,19 @@
+use super::location::RoswaalLocationName;
+
 #[derive(Debug, PartialEq, Eq)]
-pub struct RoswaalTest;
+pub struct RoswaalTest {
+    name: String,
+    commands: Vec<RoswaalTestCommand>
+}
+
+impl RoswaalTest {
+    pub fn new(name: String, commands: Vec<RoswaalTestCommand>) -> Self {
+        Self { name, commands }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RoswaalTestCommand {
+    Step { name: String, requirement: String },
+    SetLocation { location_name: RoswaalLocationName }
+}

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,5 +1,3 @@
-use std::ops::Range;
-
 pub trait ToAsciiCamelCase {
     fn to_ascii_camel_case(&self) -> String;
 }
@@ -35,36 +33,9 @@ pub trait UppercaseFirstAsciiCharacter: ToString {
 impl UppercaseFirstAsciiCharacter for String {}
 impl UppercaseFirstAsciiCharacter for &str {}
 
-pub trait FirstRangeOfString: ToString {
-    fn first_range_of_string(
-        &self,
-        string: &str
-    ) -> Option<Range<usize>> {
-        self.to_string()
-            .match_indices(string)
-            .next()
-            .map(|(i, _)| i..(i + string.len()))
-    }
-}
-
-impl FirstRangeOfString for &str {}
-impl FirstRangeOfString for String {}
-
 #[cfg(test)]
 mod string_utils_tests {
     use super::*;
-
-    #[test]
-    fn test_first_range_of_none_when_characters_not_found() {
-        let range = "hello".first_range_of_string("yay");
-        assert_eq!(range, None)
-    }
-
-    #[test]
-    fn test_first_range_of_returns_range_of_first_occurrence() {
-        let range = "hel hel".first_range_of_string("hel");
-        assert_eq!(range, Some(0..3))
-    }
 
     #[test]
     fn test_make_first_uppercase_empty() {

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 pub trait ToAsciiCamelCase {
     fn to_ascii_camel_case(&self) -> String;
 }
@@ -33,9 +35,36 @@ pub trait UppercaseFirstAsciiCharacter: ToString {
 impl UppercaseFirstAsciiCharacter for String {}
 impl UppercaseFirstAsciiCharacter for &str {}
 
+pub trait FirstRangeOfString: ToString {
+    fn first_range_of_string(
+        &self,
+        string: &str
+    ) -> Option<Range<usize>> {
+        self.to_string()
+            .match_indices(string)
+            .next()
+            .map(|(i, _)| i..(i + string.len()))
+    }
+}
+
+impl FirstRangeOfString for &str {}
+impl FirstRangeOfString for String {}
+
 #[cfg(test)]
 mod string_utils_tests {
     use super::*;
+
+    #[test]
+    fn test_first_range_of_none_when_characters_not_found() {
+        let range = "hello".first_range_of_string("yay");
+        assert_eq!(range, None)
+    }
+
+    #[test]
+    fn test_first_range_of_returns_range_of_first_occurrence() {
+        let range = "hel hel".first_range_of_string("hel");
+        assert_eq!(range, Some(0..3))
+    }
 
     #[test]
     fn test_make_first_uppercase_empty() {


### PR DESCRIPTION
The compiler for the test command syntax. Some areas of the code are not optimal at this time, but I'm happy with the test suite so refactoring shouldn't be too hard if it comes down to it.

## Approach

Overall, the idea is to parse each line of syntax, and then feed the line through the compiler until all lines have been read. During this time, the compiler will keep track of all errors, but won't stop compilation until all lines have been processed. 

### `RoswaalCompile` trait.

The entry point to the compiler is the `RoswaalCompile` trait, which is a trait that allows a type to construct itself from a `RoswaalSyntax` struct and `RoswaalCompileContext` struct. `RoswaalSyntax` holds onto the script code, and exposes a function that returns an iterator for each script line. `RoswaalCompileContext` is constructed outside the compiler and contains the necessary information for the compilation environment such as the names of all supported locations. Internally, the compile context is used as a state object that keeps track of errors and compiled commands.

`RoswaalTest` implements the `RoswaalCompile` trait. `RoswaalTest` is the domain type responsible for holding onto the compiled script information. Soon enough, I will integrate this type with the code generation output.

### Parsing

`RoswaalTestSyntax` is responsible for parsing the script, and handing the parsed script off to the compiler. Each parsed command has 3 properties:
1. A line number.
2. A name (eg. "Step", "Requirement").
3. A formal type identifier that holds information specific to the kind of command.

Additionally, each parsed line contains the line number, and empty lines are ignored.

### Possible Improvements

I ended up having to copy strings from the compiler input to the output instead of using references, I think this can be improved. There is also some rough duplication around "matchable_steps" and "matchable_requirements".

