### PR TITLE
Locations Storage

### DIFF
--- a/src/location/coordinate.rs
+++ b/src/location/coordinate.rs
@@ -1,8 +1,8 @@
 /// A latitude-longitude coordinate that assumes a spherical-earth.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct LocationCoordinate2D {
-    latitude: f32,
-    longitude: f32
+    pub(super) latitude: f32,
+    pub(super) longitude: f32
 }
 
 impl LocationCoordinate2D {

--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -1,3 +1,4 @@
 pub mod name;
 pub mod coordinate;
 pub mod location;
+pub mod storage;

--- a/src/location/name.rs
+++ b/src/location/name.rs
@@ -18,7 +18,7 @@ pub type RoswaalLocationParsingResult = Result<
 /// for formatting the name in different contexts.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RoswaalLocationName {
-    raw_value: String
+    pub(super) raw_value: String
 }
 
 impl RoswaalLocationName {

--- a/src/location/storage.rs
+++ b/src/location/storage.rs
@@ -1,0 +1,139 @@
+use anyhow::Result;
+use sqlx::{prelude::FromRow, query, query_as, Sqlite};
+
+use crate::{utils::sqlite::RoswaalSqlite, with_transaction};
+
+use super::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName};
+
+pub struct RoswaalLocationsStorage {
+    sqlite: RoswaalSqlite
+}
+
+impl RoswaalLocationsStorage {
+    pub fn new(sqlite: RoswaalSqlite) -> Self {
+        Self { sqlite }
+    }
+}
+
+const UPSERT_QUERY: &str = "
+INSERT OR REPLACE INTO Locations (latitude, longitude, name) VALUES (?, ?, ?);
+";
+
+impl RoswaalLocationsStorage {
+    pub async fn save(&self, locations: &Vec<RoswaalLocation>) -> Result<()> {
+        let mut transaction = self.sqlite.transaction().await?;
+        with_transaction!(transaction, async {
+            let statements = locations.iter()
+                .map(|_| UPSERT_QUERY)
+                .collect::<Vec<&str>>()
+                .join("\n");
+            let mut bulk_insert_query = query::<Sqlite>(&statements);
+            for location in locations.iter() {
+                bulk_insert_query = bulk_insert_query.bind(location.coordinate().latitude())
+                    .bind(location.coordinate().longitude())
+                    .bind(&location.name().raw_value)
+            }
+            bulk_insert_query.execute(transaction.connection()).await?;
+            Ok(())
+        })
+    }
+
+    pub async fn all_in_alphabetical_order(&self) -> Result<Vec<RoswaalLocation>> {
+        let mut transaction = self.sqlite.transaction().await?;
+        with_transaction!(transaction, async {
+            let locations = query_as::<Sqlite, SqliteLocation>(
+                "SELECT * FROM Locations ORDER BY name"
+            )
+            .fetch_all(transaction.connection())
+            .await?
+            .iter()
+            .map(|l| {
+                RoswaalLocation::new(
+                    RoswaalLocationName { raw_value: l.name.clone() },
+                    LocationCoordinate2D { latitude: l.latitude, longitude: l.longitude }
+                )
+            })
+            .collect();
+            Ok(locations)
+        })
+    }
+}
+
+#[derive(FromRow, Clone)]
+struct SqliteLocation {
+    latitude: f32,
+    longitude: f32,
+    name: String
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::location::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_add_and_load_locations_no_prior_locations() {
+        let storage = RoswaalLocationsStorage::new(RoswaalSqlite::in_memory().await.unwrap());
+        let locations = vec![
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("Antarctica").unwrap(),
+                LocationCoordinate2D::try_new(32.29873932, 122.3939839).unwrap()
+            ),
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("New York").unwrap(),
+                LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
+            )
+        ];
+        _ = storage.save(&locations).await;
+        let saved_locations = storage.all_in_alphabetical_order().await.unwrap();
+        assert_eq!(locations, saved_locations)
+    }
+
+    #[tokio::test]
+    async fn test_add_and_load_locations_upserts_prior_locations() {
+        let storage = RoswaalLocationsStorage::new(RoswaalSqlite::in_memory().await.unwrap());
+        let mut locations = vec![
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("Antarctica").unwrap(),
+                LocationCoordinate2D::try_new(32.29873932, 122.3939839).unwrap()
+            ),
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("New York").unwrap(),
+                LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
+            )
+        ];
+        _ = storage.save(&locations).await;
+        locations = vec![
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("Antarctica").unwrap(),
+                LocationCoordinate2D::try_new(50.0, 50.0).unwrap()
+            ),
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("Oakland").unwrap(),
+                LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
+            )
+        ];
+        _ = storage.save(&locations).await;
+        let saved_locations = storage.all_in_alphabetical_order().await.unwrap();
+        assert_eq!(
+            saved_locations,
+            vec![
+                RoswaalLocation::new(
+                    RoswaalLocationName::from_str("Antarctica").unwrap(),
+                    LocationCoordinate2D::try_new(50.0, 50.0).unwrap()
+                ),
+                RoswaalLocation::new(
+                    RoswaalLocationName::from_str("New York").unwrap(),
+                    LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
+                ),
+                RoswaalLocation::new(
+                    RoswaalLocationName::from_str("Oakland").unwrap(),
+                    LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
+                )
+            ]
+        )
+    }
+}

--- a/src/location/storage.rs
+++ b/src/location/storage.rs
@@ -1,61 +1,43 @@
 use anyhow::Result;
 use sqlx::{prelude::FromRow, query, query_as, Sqlite};
 
-use crate::{utils::sqlite::RoswaalSqlite, with_transaction};
+use crate::utils::sqlite::RoswaalSqliteTransaction;
 
 use super::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName};
 
-pub struct RoswaalLocationsStorage {
-    sqlite: RoswaalSqlite
-}
-
-impl RoswaalLocationsStorage {
-    pub fn new(sqlite: RoswaalSqlite) -> Self {
-        Self { sqlite }
-    }
-}
-
-const UPSERT_QUERY: &str = "
-INSERT OR REPLACE INTO Locations (latitude, longitude, name) VALUES (?, ?, ?);
-";
-
-impl RoswaalLocationsStorage {
-    pub async fn save(&self, locations: &Vec<RoswaalLocation>) -> Result<()> {
-        let mut transaction = self.sqlite.transaction().await?;
-        with_transaction!(transaction, async {
-            let statements = locations.iter()
-                .map(|_| UPSERT_QUERY)
-                .collect::<Vec<&str>>()
-                .join("\n");
-            let mut bulk_insert_query = query::<Sqlite>(&statements);
-            for location in locations.iter() {
-                bulk_insert_query = bulk_insert_query.bind(location.coordinate().latitude())
-                    .bind(location.coordinate().longitude())
-                    .bind(&location.name().raw_value)
-            }
-            bulk_insert_query.execute(transaction.connection()).await?;
-            Ok(())
-        })
-    }
-
-    pub async fn all_in_alphabetical_order(&self) -> Result<Vec<RoswaalLocation>> {
-        let mut transaction = self.sqlite.transaction().await?;
-        with_transaction!(transaction, async {
-            let locations = query_as::<Sqlite, SqliteLocation>(
-                "SELECT * FROM Locations ORDER BY name"
-            )
-            .fetch_all(transaction.connection())
-            .await?
-            .iter()
-            .map(|l| {
-                RoswaalLocation::new(
-                    RoswaalLocationName { raw_value: l.name.clone() },
-                    LocationCoordinate2D { latitude: l.latitude, longitude: l.longitude }
-                )
+impl <'a> RoswaalSqliteTransaction <'a> {
+    pub async fn save_locations(&mut self, locations: &Vec<RoswaalLocation>) -> Result<()> {
+        let statements = locations.iter()
+            .map(|_| {
+                "INSERT OR REPLACE INTO Locations (latitude, longitude, name) VALUES (?, ?, ?);"
             })
-            .collect();
-            Ok(locations)
+            .collect::<Vec<&str>>()
+            .join("\n");
+        let mut bulk_insert_query = query::<Sqlite>(&statements);
+        for location in locations.iter() {
+            bulk_insert_query = bulk_insert_query.bind(location.coordinate().latitude())
+                .bind(location.coordinate().longitude())
+                .bind(&location.name().raw_value)
+        }
+        bulk_insert_query.execute(self.connection()).await?;
+        Ok(())
+    }
+
+    pub async fn locations_in_alphabetical_order(&mut self) -> Result<Vec<RoswaalLocation>> {
+        let locations = query_as::<Sqlite, SqliteLocation>(
+            "SELECT * FROM Locations ORDER BY name"
+        )
+        .fetch_all(self.connection())
+        .await?
+        .iter()
+        .map(|l| {
+            RoswaalLocation::new(
+                RoswaalLocationName { raw_value: l.name.clone() },
+                LocationCoordinate2D { latitude: l.latitude, longitude: l.longitude }
+            )
         })
+        .collect();
+        Ok(locations)
     }
 }
 
@@ -70,13 +52,12 @@ struct SqliteLocation {
 mod tests {
     use std::str::FromStr;
 
-    use crate::location::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName};
-
-    use super::*;
+    use crate::{location::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName}, utils::sqlite::{RoswaalSqlite, RoswaalSqliteTransaction}};
 
     #[tokio::test]
     async fn test_add_and_load_locations_no_prior_locations() {
-        let storage = RoswaalLocationsStorage::new(RoswaalSqlite::in_memory().await.unwrap());
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
         let locations = vec![
             RoswaalLocation::new(
                 RoswaalLocationName::from_str("Antarctica").unwrap(),
@@ -87,14 +68,15 @@ mod tests {
                 LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
             )
         ];
-        _ = storage.save(&locations).await;
-        let saved_locations = storage.all_in_alphabetical_order().await.unwrap();
+        _ = transaction.save_locations(&locations).await;
+        let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
         assert_eq!(locations, saved_locations)
     }
 
     #[tokio::test]
     async fn test_add_and_load_locations_upserts_prior_locations() {
-        let storage = RoswaalLocationsStorage::new(RoswaalSqlite::in_memory().await.unwrap());
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
         let mut locations = vec![
             RoswaalLocation::new(
                 RoswaalLocationName::from_str("Antarctica").unwrap(),
@@ -105,7 +87,7 @@ mod tests {
                 LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
             )
         ];
-        _ = storage.save(&locations).await;
+        _ = transaction.save_locations(&locations).await;
         locations = vec![
             RoswaalLocation::new(
                 RoswaalLocationName::from_str("Antarctica").unwrap(),
@@ -116,8 +98,8 @@ mod tests {
                 LocationCoordinate2D::try_new(45.0, 45.0).unwrap()
             )
         ];
-        _ = storage.save(&locations).await;
-        let saved_locations = storage.all_in_alphabetical_order().await.unwrap();
+        _ = transaction.save_locations(&locations).await;
+        let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
         assert_eq!(
             saved_locations,
             vec![


### PR DESCRIPTION
Adds a couple functions to load and save locations to storage. I implemented these as extension methods on `RoswaalSqliteTransaction`, not in a separate type. A separate type requires a field for either a `RoswaalSqlite` or `RoswaalSqliteTransaction` instance. 

In the former case, we would have to create a transaction inside the individual query functions, which would limit the scope of the transaction to just the storage type. This is bad because we wouldn't be able to have the transaction run across multiple types and functions. 

The latter approach is an unnecessary abstraction. Traits are a better way of making the query functions abstract. I can create separate traits for each query function and have `RoswaalSqliteTransaction` implement each trait. Higher-level code can then depend on a generic constraint of the trait instead of `RoswaalSqliteTransaction` allowing me to change the implementation of the query functions and maintain static dispatch.

I also made some fields of some types in the `locations` module `pub(super)`. This ensured that I wouldn't need to perform any redundant validation when converting from the DB to the domain types.