### PR TITLE
Locations String Parsing

### DIFF
--- a/src/location/location.rs
+++ b/src/location/location.rs
@@ -1,4 +1,6 @@
-use super::{coordinate::LocationCoordinate2D, name::RoswaalLocationName};
+use std::str::FromStr;
+
+use super::{coordinate::LocationCoordinate2D, name::{RoswaalLocationName, RoswaalLocationNameParsingError, RoswaalLocationParsingResult}};
 
 /// A location with a name and coordinate.
 #[derive(Debug, PartialEq, Clone)]
@@ -11,6 +13,12 @@ impl RoswaalLocation {
     pub fn new(name: RoswaalLocationName, coordinate: LocationCoordinate2D) -> Self {
         Self { name, coordinate }
     }
+
+    pub(super) fn new_without_validation(name: &str, latitude: f32, longitude: f32) -> Self {
+        let name = RoswaalLocationName { raw_value: name.to_string() };
+        let coordinate = LocationCoordinate2D { latitude, longitude };
+        Self::new(name, coordinate)
+    }
 }
 
 impl RoswaalLocation {
@@ -20,5 +28,111 @@ impl RoswaalLocation {
 
     pub fn coordinate(&self) -> LocationCoordinate2D {
         self.coordinate
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RoswaalLocationStringError {
+    InvalidName(String, RoswaalLocationNameParsingError),
+    InvalidCoordinate { name: String }
+}
+
+impl FromStr for RoswaalLocation {
+    type Err = RoswaalLocationStringError;
+
+    fn from_str(l: &str) -> Result<Self, Self::Err> {
+        let splits = l.splitn(3, ",").collect::<Vec<&str>>();
+        let raw_name = splits[0];
+        let name = RoswaalLocationName::from_str(raw_name);
+        if let Err(err) = name {
+            return Err(Self::Err::InvalidName(raw_name.to_string(), err))
+        }
+        if splits.len() < 3 {
+            return Err(Self::Err::InvalidCoordinate { name: raw_name.to_string() })
+        }
+        let latitude = splits[1].trim().parse::<f32>();
+        let longitude = splits[2].trim().parse::<f32>();
+        match (name, latitude, longitude) {
+            (Ok(name), Ok(lat), Ok(lng)) => {
+                if let Some(coordinate) = LocationCoordinate2D::try_new(lat, lng) {
+                    Ok(RoswaalLocation::new(name, coordinate))
+                } else {
+                    Err(Self::Err::InvalidCoordinate { name: raw_name.to_string() })
+                }
+            },
+            _ => Err(Self::Err::InvalidCoordinate { name: raw_name.to_string() })
+        }
+    }
+}
+
+pub trait FromRoswaalStr: Sized {
+    fn from_roswaal_str(str: &str) -> Self;
+}
+
+impl FromRoswaalStr for Vec<Result<RoswaalLocation, RoswaalLocationStringError>> {
+    fn from_roswaal_str(str: &str) -> Self {
+        str.lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(RoswaalLocation::from_str)
+            .collect::<Self>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod from_str_tests {
+        use crate::location::{location::{FromRoswaalStr, RoswaalLocation, RoswaalLocationStringError}, name::RoswaalLocationNameParsingError};
+
+        #[test]
+        fn test_returns_empty_vector_when_empty_string() {
+            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_str("");
+            assert_eq!(locations, vec![])
+        }
+
+        #[test]
+        fn test_returns_locations_from_multiline_string() {
+            let str = "
+Antarctica, 50.0, 50.0
+New York, 45.0, 45.0
+San Francisco, 12.298739, 122.2989379
+
+Test 4, 0.0, 0.0
+   Whitespace   ,      2.198   ,         3.1415
+                ";
+            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_str(str);
+            let expected_locations = vec![
+                Ok(RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0)),
+                Ok(RoswaalLocation::new_without_validation("New York", 45.0, 45.0)),
+                Ok(RoswaalLocation::new_without_validation("San Francisco", 12.298739, 122.2989379)),
+                Ok(RoswaalLocation::new_without_validation("Test 4", 0.0, 0.0)),
+                Ok(RoswaalLocation::new_without_validation("   Whitespace   ", 2.198, 3.1415)),
+            ];
+            assert_eq!(locations, expected_locations)
+        }
+
+        #[test]
+        fn test_returns_errors_with_locations_from_multiline_string() {
+            let str = "
+Antarctica, 50.0, 50.0
+New York
+12.298739, 122.2989379
+Test 4, hello, 0.0
+Test 5, -80.0, world
+Test 6, -400.0, 400
+                ";
+            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_str(str);
+            let expected_locations = vec![
+                Ok(RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0)),
+                Err(RoswaalLocationStringError::InvalidCoordinate { name: "New York".to_string() }),
+                Err(RoswaalLocationStringError::InvalidName(
+                    "12.298739".to_string(),
+                    RoswaalLocationNameParsingError::InvalidFormat
+                )),
+                Err(RoswaalLocationStringError::InvalidCoordinate { name: "Test 4".to_string() }),
+                Err(RoswaalLocationStringError::InvalidCoordinate { name: "Test 5".to_string() }),
+                Err(RoswaalLocationStringError::InvalidCoordinate { name: "Test 6".to_string() })
+            ];
+            assert_eq!(locations, expected_locations)
+        }
     }
 }

--- a/src/location/location.rs
+++ b/src/location/location.rs
@@ -65,12 +65,20 @@ impl FromStr for RoswaalLocation {
     }
 }
 
-pub trait FromRoswaalStr: Sized {
-    fn from_roswaal_str(str: &str) -> Self;
+/// A trait for parsing a user input string of roswaal locations.
+///
+/// A roswaal locations string is a new line-separated string that looks like so:
+/// ```
+/// <location name>, <latitude>, <longitude>
+/// ```
+///
+/// Empty lines are ignored.
+pub trait FromRoswaalLocationsStr: Sized {
+    fn from_roswaal_locations_str(str: &str) -> Self;
 }
 
-impl FromRoswaalStr for Vec<Result<RoswaalLocation, RoswaalLocationStringError>> {
-    fn from_roswaal_str(str: &str) -> Self {
+impl FromRoswaalLocationsStr for Vec<Result<RoswaalLocation, RoswaalLocationStringError>> {
+    fn from_roswaal_locations_str(str: &str) -> Self {
         str.lines()
             .filter(|l| !l.trim().is_empty())
             .map(RoswaalLocation::from_str)
@@ -81,11 +89,11 @@ impl FromRoswaalStr for Vec<Result<RoswaalLocation, RoswaalLocationStringError>>
 #[cfg(test)]
 mod tests {
     mod from_str_tests {
-        use crate::location::{location::{FromRoswaalStr, RoswaalLocation, RoswaalLocationStringError}, name::RoswaalLocationNameParsingError};
+        use crate::location::{location::{FromRoswaalLocationsStr, RoswaalLocation, RoswaalLocationStringError}, name::RoswaalLocationNameParsingError};
 
         #[test]
         fn test_returns_empty_vector_when_empty_string() {
-            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_str("");
+            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_locations_str("");
             assert_eq!(locations, vec![])
         }
 
@@ -99,7 +107,7 @@ San Francisco, 12.298739, 122.2989379
 Test 4, 0.0, 0.0
    Whitespace   ,      2.198   ,         3.1415
                 ";
-            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_str(str);
+            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_locations_str(str);
             let expected_locations = vec![
                 Ok(RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0)),
                 Ok(RoswaalLocation::new_without_validation("New York", 45.0, 45.0)),
@@ -120,7 +128,7 @@ Test 4, hello, 0.0
 Test 5, -80.0, world
 Test 6, -400.0, 400
                 ";
-            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_str(str);
+            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_locations_str(str);
             let expected_locations = vec![
                 Ok(RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0)),
                 Err(RoswaalLocationStringError::InvalidCoordinate { name: "New York".to_string() }),


### PR DESCRIPTION
Adds parsing of location strings into `RoswaalLocation` types.

When the user enters a list of locations using the `/add-locations` slack command, they will enter something like this:
```
New York, 40.2983983, -55.98279292
Antarctica, 2.2993789, -14.398739879
...
```
Each line contains the location name, followed by the latitude, and then followed by the longitude. Empty lines are ignored by the parser.

I also added a stricter format to parsing `RoswaalLocationName`. Previously, the parsing would only fail if the location name was empty, now I included a regex to ensure that the name can be properly translated to a typescript variable name. This means that special characters are disallowed. I adjusted the compiler code to differentiate between an "unknown location" (ie. not in the locations list) and an "invalid format location".

I implemented the `FromStr` trait on `RoswaalLocation`, and then I made a custom `FromRoswaalLocationsStr` trait that is like `FromStr` but is meant for parsing the string like you see above.

Lastly, I made an internal `new_without_validation` constructor on `RoswaalLocation` that makes it easy to construct instances for testing. This constructor is now also used in the storage code to skip validation when loading from the DB.