### PR TITLE
Basic Add and Retrieve Locations Operations

### DIFF
--- a/src/generation/test_case.rs
+++ b/src/generation/test_case.rs
@@ -42,7 +42,7 @@ export const {} = async () => {{
   // Set Location to {}
   testCase.appendAction(TestActions.{})
 ",
-                        location_name.name(),
+                        location_name.raw_name(),
                         function_name
                     ),
                     test_action_code: format!(

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -247,7 +247,7 @@ mod ast_tests {
                     parse_result: parse_result.clone()
                 };
                 assert_command(line, command_name, name, command);
-                assert_eq!(name, parse_result.unwrap().name())
+                assert_eq!(name, parse_result.unwrap().raw_name())
             }
 
             fn assert_set_location_with_error(

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -175,7 +175,7 @@ impl RoswaalCompileContext {
         if !self.location_names.iter().any(|name| name.matches(&location_name)) {
             self.append_error(
                 line_number,
-                RoswaalCompilationErrorCode::UnknownLocationName(location_name.name().to_string())
+                RoswaalCompilationErrorCode::UnknownLocationName(location_name.raw_name().to_string())
             )
         } else {
             let command = CompiledCommand {

--- a/src/location/location.rs
+++ b/src/location/location.rs
@@ -14,7 +14,7 @@ impl RoswaalLocation {
         Self { name, coordinate }
     }
 
-    pub(super) fn new_without_validation(name: &str, latitude: f32, longitude: f32) -> Self {
+    pub fn new_without_validation(name: &str, latitude: f32, longitude: f32) -> Self {
         let name = RoswaalLocationName { raw_value: name.to_string() };
         let coordinate = LocationCoordinate2D { latitude, longitude };
         Self::new(name, coordinate)

--- a/src/location/location.rs
+++ b/src/location/location.rs
@@ -73,6 +73,7 @@ impl FromStr for RoswaalLocation {
 /// ```
 ///
 /// Empty lines are ignored.
+#[derive(Debug, PartialEq)]
 pub struct RoswaalStringLocations {
     results: Vec<Result<RoswaalLocation, RoswaalLocationStringError>>
 }

--- a/src/location/location.rs
+++ b/src/location/location.rs
@@ -65,7 +65,7 @@ impl FromStr for RoswaalLocation {
     }
 }
 
-/// A trait for parsing a user input string of roswaal locations.
+/// A type for parsing a user input string of roswaal locations.
 ///
 /// A roswaal locations string is a new line-separated string that looks like so:
 /// ```
@@ -73,28 +73,43 @@ impl FromStr for RoswaalLocation {
 /// ```
 ///
 /// Empty lines are ignored.
-pub trait FromRoswaalLocationsStr: Sized {
-    fn from_roswaal_locations_str(str: &str) -> Self;
+pub struct RoswaalStringLocations {
+    results: Vec<Result<RoswaalLocation, RoswaalLocationStringError>>
 }
 
-impl FromRoswaalLocationsStr for Vec<Result<RoswaalLocation, RoswaalLocationStringError>> {
-    fn from_roswaal_locations_str(str: &str) -> Self {
-        str.lines()
+impl RoswaalStringLocations {
+    pub fn from_roswaal_locations_str(str: &str) -> Self {
+        let results = str.lines()
             .filter(|l| !l.trim().is_empty())
             .map(RoswaalLocation::from_str)
-            .collect::<Self>()
+            .collect::<Vec<Result<RoswaalLocation, RoswaalLocationStringError>>>();
+        Self { results }
+    }
+}
+
+impl RoswaalStringLocations {
+    pub fn locations(&self) -> Vec<RoswaalLocation> {
+        self.results()
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|l| l.clone())
+            .collect::<Vec<RoswaalLocation>>()
+    }
+
+    pub fn results(&self) -> &Vec<Result<RoswaalLocation, RoswaalLocationStringError>> {
+        &self.results
     }
 }
 
 #[cfg(test)]
 mod tests {
     mod from_str_tests {
-        use crate::location::{location::{FromRoswaalLocationsStr, RoswaalLocation, RoswaalLocationStringError}, name::RoswaalLocationNameParsingError};
+        use crate::location::{location::{RoswaalLocation, RoswaalLocationStringError, RoswaalStringLocations}, name::RoswaalLocationNameParsingError};
 
         #[test]
         fn test_returns_empty_vector_when_empty_string() {
-            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_locations_str("");
-            assert_eq!(locations, vec![])
+            let locations = RoswaalStringLocations::from_roswaal_locations_str("");
+            assert_eq!(locations.results(), &vec![])
         }
 
         #[test]
@@ -107,7 +122,7 @@ San Francisco, 12.298739, 122.2989379
 Test 4, 0.0, 0.0
    Whitespace   ,      2.198   ,         3.1415
                 ";
-            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_locations_str(str);
+            let locations = RoswaalStringLocations::from_roswaal_locations_str(str);
             let expected_locations = vec![
                 Ok(RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0)),
                 Ok(RoswaalLocation::new_without_validation("New York", 45.0, 45.0)),
@@ -115,7 +130,7 @@ Test 4, 0.0, 0.0
                 Ok(RoswaalLocation::new_without_validation("Test 4", 0.0, 0.0)),
                 Ok(RoswaalLocation::new_without_validation("   Whitespace   ", 2.198, 3.1415)),
             ];
-            assert_eq!(locations, expected_locations)
+            assert_eq!(locations.results(), &expected_locations);
         }
 
         #[test]
@@ -128,7 +143,7 @@ Test 4, hello, 0.0
 Test 5, -80.0, world
 Test 6, -400.0, 400
                 ";
-            let locations = Vec::<Result<RoswaalLocation, RoswaalLocationStringError>>::from_roswaal_locations_str(str);
+            let locations = RoswaalStringLocations::from_roswaal_locations_str(str);
             let expected_locations = vec![
                 Ok(RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0)),
                 Err(RoswaalLocationStringError::InvalidCoordinate { name: "New York".to_string() }),
@@ -140,7 +155,7 @@ Test 6, -400.0, 400
                 Err(RoswaalLocationStringError::InvalidCoordinate { name: "Test 5".to_string() }),
                 Err(RoswaalLocationStringError::InvalidCoordinate { name: "Test 6".to_string() })
             ];
-            assert_eq!(locations, expected_locations)
+            assert_eq!(locations.results(), &expected_locations)
         }
     }
 }

--- a/src/location/name.rs
+++ b/src/location/name.rs
@@ -26,7 +26,7 @@ pub struct RoswaalLocationName {
 }
 
 impl RoswaalLocationName {
-    pub fn name(&self) -> &str {
+    pub fn raw_name(&self) -> &str {
         &self.raw_value
     }
 }
@@ -61,14 +61,14 @@ impl RoswaalLocationName {
     /// assert!(name.matches("  Hello  World  "))
     /// ```
     pub fn matches(&self, other: &Self) -> bool {
-        self.name().roswaal_normalize() == other.name().roswaal_normalize()
+        self.raw_name().roswaal_normalize() == other.raw_name().roswaal_normalize()
     }
 }
 
 impl RoswaalLocationName {
     /// Returns this name in `PascalCase` as a raw String.
     pub fn to_ascii_pascal_case_string(&self) -> String {
-        self.name().to_ascii_pascal_case()
+        self.raw_name().to_ascii_pascal_case()
     }
 }
 
@@ -108,7 +108,7 @@ mod roswaal_location_tests {
         ];
         for str in strings {
             let name = RoswaalLocationName::from_str(str).unwrap();
-            assert_eq!(name.name(), str);
+            assert_eq!(name.raw_name(), str);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod utils;
 mod generation;
 mod location;
 mod git;
+mod operations;
 
 fn main() {
     println!("Hello, world!");

--- a/src/operations/add_locations.rs
+++ b/src/operations/add_locations.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use crate::{location::location::RoswaalLocation, utils::sqlite::RoswaalSqlite, with_transaction};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AddLocationsResult {
+    Success,
+    NoLocationsAdded
+}
+
+impl AddLocationsResult {
+    pub async fn from_adding_locations(
+        locations: &Vec<RoswaalLocation>,
+        sqlite: &RoswaalSqlite
+    ) -> Result<Self> {
+        if locations.is_empty() {
+            return Ok(Self::NoLocationsAdded)
+        }
+        let mut transaction = sqlite.transaction().await?;
+        with_transaction!(transaction, async {
+            transaction.save_locations(locations).await?;
+            Ok(Self::Success)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::{location::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName}, operations::add_locations::AddLocationsResult, utils::sqlite::RoswaalSqlite};
+
+    #[tokio::test]
+    async fn test_success_when_adding_locations_smoothly() {
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let locations = vec![
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("Test").unwrap(),
+                LocationCoordinate2D::try_new(50.0, 50.0).unwrap()
+            )
+        ];
+        let result = AddLocationsResult::from_adding_locations(&locations, &sqlite).await;
+        assert_eq!(result.ok(), Some(AddLocationsResult::Success))
+    }
+
+    #[tokio::test]
+    async fn test_no_locations_added_when_empty_vector() {
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let result = AddLocationsResult::from_adding_locations(&vec![], &sqlite).await;
+        assert_eq!(result.ok(), Some(AddLocationsResult::NoLocationsAdded))
+    }
+}

--- a/src/operations/load_all_locations.rs
+++ b/src/operations/load_all_locations.rs
@@ -44,6 +44,7 @@ mod tests {
         ];
         let locations_str = "
 Test 1, 50.0, 50.0
+Invalid
 Test 2, -5.0, 5.0
             ";
         _ = AddLocationsResult::from_adding_locations(&locations_str, &sqlite).await.unwrap();

--- a/src/operations/load_all_locations.rs
+++ b/src/operations/load_all_locations.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use crate::{location::location::RoswaalLocation, utils::sqlite::RoswaalSqlite, with_transaction};
+
+#[derive(Debug, PartialEq)]
+pub enum LoadAllLocationsResult {
+    Success(Vec<RoswaalLocation>),
+    NoLocations
+}
+
+impl LoadAllLocationsResult {
+    pub async fn from_stored_locations(
+        sqlite: &RoswaalSqlite
+    ) -> Result<Self> {
+        let mut transaction = sqlite.transaction().await?;
+        with_transaction!(transaction, async {
+            transaction.locations_in_alphabetical_order().await.map(|locations| {
+                if locations.is_empty() { Self::NoLocations } else { Self::Success(locations) }
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::{location::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName}, operations::{add_locations::AddLocationsResult, load_all_locations::LoadAllLocationsResult}, utils::sqlite::RoswaalSqlite};
+
+    #[tokio::test]
+    async fn test_returns_no_locations_when_no_saved_locations() {
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let result = LoadAllLocationsResult::from_stored_locations(&sqlite).await.unwrap();
+        assert_eq!(result, LoadAllLocationsResult::NoLocations)
+    }
+
+    #[tokio::test]
+    async fn test_returns_locations_from_add_operation() {
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let locations = vec![
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("Test 1").unwrap(),
+                LocationCoordinate2D::try_new(50.0, 50.0).unwrap()
+            ),
+            RoswaalLocation::new(
+                RoswaalLocationName::from_str("Test 2").unwrap(),
+                LocationCoordinate2D::try_new(-5.0, 5.0).unwrap()
+            )
+        ];
+        _ = AddLocationsResult::from_adding_locations(&locations, &sqlite).await.unwrap();
+        let result = LoadAllLocationsResult::from_stored_locations(&sqlite).await.unwrap();
+        assert_eq!(result, LoadAllLocationsResult::Success(locations))
+    }
+}

--- a/src/operations/load_all_locations.rs
+++ b/src/operations/load_all_locations.rs
@@ -14,7 +14,11 @@ impl LoadAllLocationsResult {
         let mut transaction = sqlite.transaction().await?;
         with_transaction!(transaction, async {
             transaction.locations_in_alphabetical_order().await.map(|locations| {
-                if locations.is_empty() { Self::NoLocations } else { Self::Success(locations) }
+                if locations.is_empty() {
+                    Self::NoLocations
+                } else {
+                    Self::Success(locations)
+                }
             })
         })
     }
@@ -22,9 +26,7 @@ impl LoadAllLocationsResult {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use crate::{location::{coordinate::LocationCoordinate2D, location::RoswaalLocation, name::RoswaalLocationName}, operations::{add_locations::AddLocationsResult, load_all_locations::LoadAllLocationsResult}, utils::sqlite::RoswaalSqlite};
+    use crate::{location::location::RoswaalLocation, operations::{add_locations::AddLocationsResult, load_all_locations::LoadAllLocationsResult}, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn test_returns_no_locations_when_no_saved_locations() {
@@ -37,16 +39,14 @@ mod tests {
     async fn test_returns_locations_from_add_operation() {
         let sqlite = RoswaalSqlite::in_memory().await.unwrap();
         let locations = vec![
-            RoswaalLocation::new(
-                RoswaalLocationName::from_str("Test 1").unwrap(),
-                LocationCoordinate2D::try_new(50.0, 50.0).unwrap()
-            ),
-            RoswaalLocation::new(
-                RoswaalLocationName::from_str("Test 2").unwrap(),
-                LocationCoordinate2D::try_new(-5.0, 5.0).unwrap()
-            )
+            RoswaalLocation::new_without_validation("Test 1", 50.0, 50.0),
+            RoswaalLocation::new_without_validation("Test 2", -5.0, 5.0)
         ];
-        _ = AddLocationsResult::from_adding_locations(&locations, &sqlite).await.unwrap();
+        let locations_str = "
+Test 1, 50.0, 50.0
+Test 2, -5.0, 5.0
+            ";
+        _ = AddLocationsResult::from_adding_locations(&locations_str, &sqlite).await.unwrap();
         let result = LoadAllLocationsResult::from_stored_locations(&sqlite).await.unwrap();
         assert_eq!(result, LoadAllLocationsResult::Success(locations))
     }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,0 +1,2 @@
+pub mod add_locations;
+pub mod load_all_locations;


### PR DESCRIPTION
Adds basic high-level code for adding and retrieving locations. This high-level code lives in a new `operations` module, in which each operation will have a separate file. 

You can think of each operation file as performing the main logic for an HTTP API endpoint, but instead of returning an HTTP Response, we return a domain-specific result type instead. The domain-specific result type can then be translated into an HTTP Response.

So why have this separation, doesn't it add a needless translation layer? Most HTTP endpoints will be interacted with through Slack, in other words, we'll need to respond with a UI json representation and not a raw data json representation (like in a typical HTTP API). Since that UI representation will likely have a higher rate of change than the needs of the high-level business operations, it would be wise to separate those 2 things. For instance, this means that changes to the UI code wouldn't invalidate any tests that test the main logic.

For now, there are 2 operations for adding and retrieving all locations. The add operation will eventually need to generate code, add git commits, and open a PR on the frontend repo, but I'll leave that for future PRs. As of right now, only the data persistence and retrieval is implemented.

I also made some adjustments to the locations string parsing. Before, I used an extension trait on a vector for the parsing API. I've replaced the vector and extension trait with the `RoswaalStringLocations` type which has methods for querying the locations that were successfully parsed from the locations string.