### PR TITLE
Unique Branch Names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1168,7 @@ name = "roswaal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "nanoid",
  "once_cell",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"
+nanoid = "0.4.0"
 once_cell = "1.19.0"
 regex = "1.10.4"
 reqwest = { version = "0.12.4", features = ["json"] }

--- a/src/git/branch_name.rs
+++ b/src/git/branch_name.rs
@@ -1,0 +1,22 @@
+use nanoid::nanoid;
+
+/// A type for a git branch name that is created by roswaal.
+///
+/// Each branch name contains a 10 character nano id as its suffix in order to make each instance
+/// unique. This uniqueness ensures that duplicate branch names do not clash with each other.
+#[derive(Debug, PartialEq, Eq)]
+pub struct RoswaalGitBranchName {
+    raw_name: String
+}
+
+impl RoswaalGitBranchName {
+    pub fn new(name: &str) -> Self {
+        Self { raw_name: format!("roswaal:{}:{}", name, nanoid!(10)) }
+    }
+}
+
+impl ToString for RoswaalGitBranchName {
+    fn to_string(&self) -> String {
+        self.raw_name.clone()
+    }
+}

--- a/src/git/metadata.rs
+++ b/src/git/metadata.rs
@@ -1,23 +1,25 @@
 use crate::{language::ast::RoswaalTestSyntax, location::location::RoswaalStringLocations};
 
-use super::pull_request::GithubPullRequest;
+use super::{branch_name::RoswaalGitBranchName, pull_request::GithubPullRequest};
 
 /// A struct containing neccessary metadata for operating in a roswaal compatible git repo.
 pub struct RoswaalGitRepoMetadata {
+    base_branch_name: String,
     repo_root_dir_path: String,
     test_cases_root_dir_path: String,
     add_test_cases_pr: fn(
         test_names_with_syntax: Vec<(&str, RoswaalTestSyntax)>,
-        head_branch: String
+        RoswaalGitBranchName
     ) -> GithubPullRequest,
     locations_path: String,
-    add_locations_pr: fn(RoswaalStringLocations, head_branch: String) -> GithubPullRequest
+    add_locations_pr: fn(RoswaalStringLocations, RoswaalGitBranchName) -> GithubPullRequest
 }
 
 impl RoswaalGitRepoMetadata {
     /// Metadata for the main frontend repo.
     pub fn for_tif_react_frontend() -> Self {
         Self {
+            base_branch_name: "development".to_string(),
             repo_root_dir_path: "./FitnessProject".to_string(),
             test_cases_root_dir_path: "./FitnessProject/roswaal".to_string(),
             add_test_cases_pr: GithubPullRequest::for_test_cases_tif_react_frontend,
@@ -29,6 +31,7 @@ impl RoswaalGitRepoMetadata {
     /// Metadata for a local testing repo.
     pub fn for_testing() -> Self {
         Self {
+            base_branch_name: "development".to_string(),
             repo_root_dir_path: "./FitnessProjectTests".to_string(),
             test_cases_root_dir_path: "./FitnessProjectTests/roswaal".to_string(),
             add_test_cases_pr: |cases, head_branch| {

--- a/src/git/metadata.rs
+++ b/src/git/metadata.rs
@@ -1,0 +1,45 @@
+use crate::{language::ast::RoswaalTestSyntax, location::location::RoswaalStringLocations};
+
+use super::pull_request::GithubPullRequest;
+
+/// A struct containing neccessary metadata for operating in a roswaal compatible git repo.
+pub struct RoswaalGitRepoMetadata {
+    repo_root_dir_path: String,
+    test_cases_root_dir_path: String,
+    add_test_cases_pr: fn(
+        test_names_with_syntax: Vec<(&str, RoswaalTestSyntax)>,
+        head_branch: String
+    ) -> GithubPullRequest,
+    locations_path: String,
+    add_locations_pr: fn(RoswaalStringLocations, head_branch: String) -> GithubPullRequest
+}
+
+impl RoswaalGitRepoMetadata {
+    /// Metadata for the main frontend repo.
+    pub fn for_tif_react_frontend() -> Self {
+        Self {
+            repo_root_dir_path: "./FitnessProject".to_string(),
+            test_cases_root_dir_path: "./FitnessProject/roswaal".to_string(),
+            add_test_cases_pr: GithubPullRequest::for_test_cases_tif_react_frontend,
+            locations_path: "./FitnessProject/rosswaal/Locations.ts".to_string(),
+            add_locations_pr: GithubPullRequest::for_locations_tif_react_frontend
+        }
+    }
+
+    /// Metadata for a local testing repo.
+    pub fn for_testing() -> Self {
+        Self {
+            repo_root_dir_path: "./FitnessProjectTests".to_string(),
+            test_cases_root_dir_path: "./FitnessProjectTests/roswaal".to_string(),
+            add_test_cases_pr: |cases, head_branch| {
+                GithubPullRequest::for_test_cases_tif_react_frontend(cases, head_branch)
+                    .for_testing_do_not_merge()
+            },
+            locations_path: "./FitnessProjectTests/rosswaal/Locations.ts".to_string(),
+            add_locations_pr: |locations, head_branch| {
+                GithubPullRequest::for_locations_tif_react_frontend(locations, head_branch)
+                    .for_testing_do_not_merge()
+            }
+        }
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,2 +1,3 @@
 pub mod pull_request;
 pub mod metadata;
+pub mod branch_name;

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,1 +1,2 @@
 pub mod pull_request;
+pub mod metadata;

--- a/src/git/pull_request.rs
+++ b/src/git/pull_request.rs
@@ -75,8 +75,8 @@ Since I am Roswaaaaaaal, I do not need to specify any tiiiiiiiickets!
     }
 
     /// Creates a PR for test case creation on the frontend repo.
-    pub fn for_test_cases_tif_react_frontend<'a>(
-        test_names_with_syntax: Vec<(&str, RoswaalTestSyntax<'a>)>,
+    pub fn for_test_cases_tif_react_frontend<'a, 'b>(
+        test_names_with_syntax: Vec<(&'a str, RoswaalTestSyntax<'b>)>,
         head_branch: String
     ) -> Self {
         let joined_names = test_names_with_syntax.iter()

--- a/src/git/pull_request.rs
+++ b/src/git/pull_request.rs
@@ -4,6 +4,8 @@ use anyhow::Result;
 use reqwest::{header::CONTENT_TYPE, Client};
 use serde::Serialize;
 
+use crate::location::location::{RoswaalLocationStringError, RoswaalStringLocations};
+
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct GithubPullRequest {
     title: String,
@@ -28,6 +30,41 @@ impl GithubPullRequest {
             head: format!("roswaal:{}", head_branch)
         }
     }
+
+    /// Creates a PR associated with adding new locations to the main frontend repo.
+    pub fn for_locations_tif_react_frontend(
+        string_locations: RoswaalStringLocations,
+        head_branch: String
+    ) -> Self {
+        let title = format!("Add Locations ({})", string_locations.raw_names().join(", "));
+        let mut body = "Adds the following locations to the acceptance teeeeeeeeeests:\n".to_string();
+        for location in string_locations.locations() {
+            let line = format!(
+                "- **{}** (Latitude: {:.16}, Longitude: {:.16})\n",
+                location.name().raw_name(),
+                location.coordinate().latitude(),
+                location.coordinate().longitude()
+            );
+            body.push_str(&line)
+        }
+        let errors = string_locations.errors();
+        if !errors.is_empty() {
+            body.push_str("\nThe following locations were specified in the slack command, but are invaaaaaaaalid:\n");
+            for error in errors {
+                body.push_str(&format!("- **{}** ", error.raw_associated_location_name()));
+                match error {
+                    RoswaalLocationStringError::InvalidName(_, _) => {
+                        body.push_str("(Invalid Name)")
+                    },
+                    RoswaalLocationStringError::InvalidCoordinate { name: _ } => {
+                        body.push_str("(Invalid Coordinate)")
+                    }
+                };
+                body.push_str("\n")
+            }
+        }
+        Self::for_tif_react_frontend(title, body, head_branch)
+    }
 }
 
 pub trait GithubPullRequestOpen {
@@ -50,5 +87,52 @@ impl GithubPullRequestOpen for Client {
             .send()
             .await?;
         Ok(response.status() == 201)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::location::location::RoswaalStringLocations;
+
+    use super::GithubPullRequest;
+
+    #[test]
+    fn test_from_string_locations_with_invalid_locations() {
+        let locations_str = "
+Test 1, 45.0, 4.0
+908308
+Test 2, -78.290782973, 54.309983793
+Invalid, hello, world
+            ";
+        let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
+        let branch_name = "test-locations-branch".to_string();
+        let pr = GithubPullRequest::for_locations_tif_react_frontend(string_locations, branch_name);
+        assert_eq!(pr.title, "Roswaal: Add Locations (Test 1, 908308, Test 2, Invalid)".to_string());
+        let expected_body = "Adds the following locations to the acceptance teeeeeeeeeests:
+- **Test 1** (Latitude: 45.0000000000000000, Longitude: 4.0000000000000000)
+- **Test 2** (Latitude: -78.2907867431640625, Longitude: 54.3099822998046875)
+
+The following locations were specified in the slack command, but are invaaaaaaaalid:
+- **908308** (Invalid Name)
+- **Invalid** (Invalid Coordinate)
+";
+        assert!(pr.body.contains(expected_body));
+    }
+
+    #[test]
+    fn test_from_string_locations_only_valid_locations_omits_invalid_section() {
+        let locations_str = "
+Test 1, 45.0, 4.0
+Test 2, -78.290782973, 54.309983793
+            ";
+        let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
+        let branch_name = "test-locations-branch".to_string();
+        let pr = GithubPullRequest::for_locations_tif_react_frontend(string_locations, branch_name);
+        assert_eq!(pr.title, "Roswaal: Add Locations (Test 1, Test 2)".to_string());
+        let expected_body = "Adds the following locations to the acceptance teeeeeeeeeests:
+- **Test 1** (Latitude: 45.0000000000000000, Longitude: 4.0000000000000000)
+- **Test 2** (Latitude: -78.2907867431640625, Longitude: 54.3099822998046875)
+";
+        assert!(pr.body.contains(expected_body));
     }
 }

--- a/src/git/pull_request.rs
+++ b/src/git/pull_request.rs
@@ -67,6 +67,20 @@ impl GithubPullRequest {
     }
 }
 
+impl GithubPullRequest {
+    /// Designates this PR specifically for testing and adjusts the title and body to disclaim
+    /// that it should not be merged.
+    ///
+    /// This is useful for E2E tests.
+    pub fn for_testing_do_not_merge(self) -> Self {
+        Self {
+            title: format!("[Test - DO NOT MERGE] {}", self.title),
+            body: format!("This is a test PR, please do not meeeeeeerge!!!\n\n{}", self.body),
+            ..self
+        }
+    }
+}
+
 pub trait GithubPullRequestOpen {
     /// Opens a PR on github, and returns true if it was created successfully.
     async fn open(&self, pull_request: &GithubPullRequest) -> Result<bool>;
@@ -95,6 +109,18 @@ mod tests {
     use crate::location::location::RoswaalStringLocations;
 
     use super::GithubPullRequest;
+
+    #[test]
+    fn test_do_not_merge_specifies_do_not_merge_in_title_and_body() {
+        let pr = GithubPullRequest::for_tif_react_frontend(
+            "Hello".to_string(),
+            "World".to_string(),
+            "test".to_string()
+        )
+        .for_testing_do_not_merge();
+        assert_eq!(pr.title, "[Test - DO NOT MERGE] Roswaal: Hello");
+        assert!(pr.body.starts_with("This is a test PR, please do not meeeeeeerge!!!\n\n"))
+    }
 
     #[test]
     fn test_from_string_locations_with_invalid_locations() {

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -119,6 +119,10 @@ impl <'a> RoswaalTestSyntax<'a> {
             line_count as u32
         }
     }
+
+    pub fn source_code(&self) -> &str {
+        &self.source_code
+    }
 }
 
 impl <'a> From<&'a str> for RoswaalTestSyntax<'a> {

--- a/src/location/location.rs
+++ b/src/location/location.rs
@@ -31,10 +31,20 @@ impl RoswaalLocation {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RoswaalLocationStringError {
     InvalidName(String, RoswaalLocationNameParsingError),
     InvalidCoordinate { name: String }
+}
+
+impl RoswaalLocationStringError {
+    /// Returns the raw stringified location name associated with this error.
+    pub fn raw_associated_location_name(&self) -> &str {
+        match self {
+            Self::InvalidName(name, _) => name,
+            Self::InvalidCoordinate { name } => name
+        }
+    }
 }
 
 impl FromStr for RoswaalLocation {
@@ -89,16 +99,40 @@ impl RoswaalStringLocations {
 }
 
 impl RoswaalStringLocations {
+    /// Returns the successfully parsed locations in their original string order.
     pub fn locations(&self) -> Vec<RoswaalLocation> {
         self.results()
             .iter()
             .filter_map(|r| r.as_ref().ok())
             .map(|l| l.clone())
-            .collect::<Vec<RoswaalLocation>>()
+            .collect()
     }
 
+    /// Returns the errors of unsuccessfully parsed locations in their original string order.
+    pub fn errors(&self) -> Vec<RoswaalLocationStringError> {
+        self.results()
+            .iter()
+            .filter_map(|r| r.as_ref().err())
+            .map(|err| err.clone())
+            .collect()
+    }
+
+    /// Returns the parse result of each location in their original string order.
     pub fn results(&self) -> &Vec<Result<RoswaalLocation, RoswaalLocationStringError>> {
         &self.results
+    }
+}
+
+impl RoswaalStringLocations {
+    /// Returns a vector of the raw location names of each location line.
+    pub fn raw_names(&self) -> Vec<&str> {
+        self.results().iter().map(|r| {
+            match r {
+                Ok(l) => l.name().raw_name(),
+                Err(err) => err.raw_associated_location_name()
+            }
+        })
+        .collect()
     }
 }
 


### PR DESCRIPTION
Roswaal will need to create a separate git branch name based on the test/location names that users specify. However, in the case of failures, a user may want to retry a command with the exact same/or slightly different input which can cause a duplicate branch name to be created. To counter this, I have made a `RoswaalGitBranchName` struct which appends a 10-character nanoid to the end of the branch name. I chose nanoids over uuids since the former is more readable. 