### PR TITLE
Git Client Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,11 @@ name = "cc"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cfg-if"
@@ -457,6 +462,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +718,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +744,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1168,6 +1237,7 @@ name = "roswaal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "git2",
  "nanoid",
  "once_cell",
  "regex",
@@ -1348,6 +1418,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1756,6 +1835,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"
+git2 = "0.19.0"
 nanoid = "0.4.0"
 once_cell = "1.19.0"
 regex = "1.10.4"
@@ -16,4 +17,4 @@ serde_json = "1.0.117"
 sqlx = { version = "0.7.4", features = ["runtime-tokio", "sqlite", "macros"] }
 strum = "0.26.2"
 strum_macros = "0.26.2"
-tokio = { version = "1.38.0", features = ["rt", "macros"] }
+tokio = { version = "1.38.0", features = ["rt", "macros", "process"] }

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,4 @@ if [ $? -ne 0 ]; then
 fi
 echo "✅ Successfully pulled latest development branch"
 cd ..
-echo "🔵 Creating test repo (this is used as an isolated environment for integration tests)"
-mkdir -p FitnessProjectTest/roswaal
-touch FitnessProjectTest/roswaal/Locations.ts
-echo "✅ Successfully setup test repo"
+./setup_test_repo.sh

--- a/setup_test_repo.sh
+++ b/setup_test_repo.sh
@@ -1,0 +1,11 @@
+rm -drf FitnessProjectTest > /dev/null
+echo "🔵 Creating test repo (this is used as an isolated environment for integration tests)"
+mkdir -p FitnessProjectTest/roswaal
+cd FitnessProjectTest
+git init
+git remote add origin git@github.com:roswaaltifbot/FitnessProjectTest.git
+git branch -M main
+touch roswaal/Locations.ts
+git add .
+git commit -m "Add Locations.ts"
+echo "✅ Successfully setup test repo"

--- a/src/git/branch_name.rs
+++ b/src/git/branch_name.rs
@@ -5,17 +5,17 @@ use nanoid::nanoid;
 /// Each branch name contains a 10 character nano id as its suffix in order to make each instance
 /// unique. This uniqueness ensures that duplicate branch names do not clash with each other.
 #[derive(Debug, PartialEq, Eq)]
-pub struct RoswaalGitBranchName {
+pub struct RoswaalOwnedGitBranchName {
     raw_name: String
 }
 
-impl RoswaalGitBranchName {
+impl RoswaalOwnedGitBranchName {
     pub fn new(name: &str) -> Self {
-        Self { raw_name: format!("roswaal:{}:{}", name, nanoid!(10)) }
+        Self { raw_name: format!("roswaal_{}_{}", name, nanoid!(10)) }
     }
 }
 
-impl ToString for RoswaalGitBranchName {
+impl ToString for RoswaalOwnedGitBranchName {
     fn to_string(&self) -> String {
         self.raw_name.clone()
     }

--- a/src/git/metadata.rs
+++ b/src/git/metadata.rs
@@ -1,26 +1,33 @@
-use crate::{language::ast::RoswaalTestSyntax, location::location::RoswaalStringLocations};
+use std::env;
 
-use super::{branch_name::RoswaalGitBranchName, pull_request::GithubPullRequest};
+use crate::{language::ast::RoswaalTestSyntax, location::location::RoswaalStringLocations};
+use super::{branch_name::RoswaalOwnedGitBranchName, pull_request::GithubPullRequest};
 
 /// A struct containing neccessary metadata for operating in a roswaal compatible git repo.
-pub struct RoswaalGitRepoMetadata {
+#[derive(Debug, Clone)]
+pub struct RoswaalGitRepositoryMetadata {
     base_branch_name: String,
     repo_root_dir_path: String,
+    ssh_private_key_home_path: String,
     test_cases_root_dir_path: String,
     add_test_cases_pr: fn(
         test_names_with_syntax: Vec<(&str, RoswaalTestSyntax)>,
-        RoswaalGitBranchName
+        RoswaalOwnedGitBranchName
     ) -> GithubPullRequest,
     locations_path: String,
-    add_locations_pr: fn(RoswaalStringLocations, RoswaalGitBranchName) -> GithubPullRequest
+    add_locations_pr: fn(
+        RoswaalStringLocations,
+        RoswaalOwnedGitBranchName
+    ) -> GithubPullRequest
 }
 
-impl RoswaalGitRepoMetadata {
+impl RoswaalGitRepositoryMetadata {
     /// Metadata for the main frontend repo.
     pub fn for_tif_react_frontend() -> Self {
         Self {
             base_branch_name: "development".to_string(),
             repo_root_dir_path: "./FitnessProject".to_string(),
+            ssh_private_key_home_path: "./.ssh/id_rsa".to_string(),
             test_cases_root_dir_path: "./FitnessProject/roswaal".to_string(),
             add_test_cases_pr: GithubPullRequest::for_test_cases_tif_react_frontend,
             locations_path: "./FitnessProject/rosswaal/Locations.ts".to_string(),
@@ -31,18 +38,38 @@ impl RoswaalGitRepoMetadata {
     /// Metadata for a local testing repo.
     pub fn for_testing() -> Self {
         Self {
-            base_branch_name: "development".to_string(),
-            repo_root_dir_path: "./FitnessProjectTests".to_string(),
-            test_cases_root_dir_path: "./FitnessProjectTests/roswaal".to_string(),
+            base_branch_name: "main".to_string(),
+            repo_root_dir_path: "./FitnessProjectTest".to_string(),
+            ssh_private_key_home_path: "./.ssh/id_mhayes".to_string(),
+            test_cases_root_dir_path: "./FitnessProjectTest/roswaal".to_string(),
             add_test_cases_pr: |cases, head_branch| {
                 GithubPullRequest::for_test_cases_tif_react_frontend(cases, head_branch)
                     .for_testing_do_not_merge()
             },
-            locations_path: "./FitnessProjectTests/rosswaal/Locations.ts".to_string(),
+            locations_path: "./FitnessProjectTest/rosswaal/Locations.ts".to_string(),
             add_locations_pr: |locations, head_branch| {
                 GithubPullRequest::for_locations_tif_react_frontend(locations, head_branch)
                     .for_testing_do_not_merge()
             }
         }
+    }
+}
+
+impl RoswaalGitRepositoryMetadata {
+    /// Returns the name of the branch that changes are primarily merged to (eg. development).
+    pub fn base_branch_name(&self) -> &str {
+        &self.base_branch_name
+    }
+
+    /// Returns a string path to the private ssh key to use when pushing and pulling changes from
+    /// the remote repository.
+    pub fn ssh_private_key_path(&self) -> String {
+        let home = env::var("HOME").unwrap();
+        format!("{}/{}", home, self.ssh_private_key_home_path)
+    }
+
+    /// Returns a string path relative to the root directory of the repository.
+    pub fn relative_path(&self, path: &str) -> String {
+        format!("{}/{}", self.repo_root_dir_path, path)
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,3 +1,4 @@
 pub mod pull_request;
 pub mod metadata;
 pub mod branch_name;
+pub mod repo;

--- a/src/git/pull_request.rs
+++ b/src/git/pull_request.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use crate::{language::ast::RoswaalTestSyntax, location::location::{RoswaalLocationStringError, RoswaalStringLocations}};
 
-use super::branch_name::RoswaalGitBranchName;
+use super::branch_name::RoswaalOwnedGitBranchName;
 
 /// A serializeable type for a pull request on github.
 #[derive(Debug, PartialEq, Eq, Serialize)]
@@ -26,7 +26,7 @@ impl GithubPullRequest {
     pub fn for_tif_react_frontend(
         title: String,
         body: String,
-        head_branch: RoswaalGitBranchName
+        head_branch: RoswaalOwnedGitBranchName
     ) -> Self {
         Self {
             body: format!(
@@ -48,7 +48,7 @@ Since I am Roswaaaaaaal, I do not need to specify any tiiiiiiiickets!
     /// Creates a PR associated with adding new locations to the main frontend repo.
     pub fn for_locations_tif_react_frontend(
         string_locations: RoswaalStringLocations,
-        head_branch: RoswaalGitBranchName
+        head_branch: RoswaalOwnedGitBranchName
     ) -> Self {
         let title = format!("Add Locations ({})", string_locations.raw_names().join(", "));
         let mut body = "Adds the following locations to the acceptance teeeeeeeeeests:\n".to_string();
@@ -83,7 +83,7 @@ Since I am Roswaaaaaaal, I do not need to specify any tiiiiiiiickets!
     /// Creates a PR for test case creation on the frontend repo.
     pub fn for_test_cases_tif_react_frontend<'a, 'b>(
         test_names_with_syntax: Vec<(&'a str, RoswaalTestSyntax<'b>)>,
-        head_branch: RoswaalGitBranchName
+        head_branch: RoswaalOwnedGitBranchName
     ) -> Self {
         let joined_names = test_names_with_syntax.iter()
             .map(|(name, _)| name.to_string())
@@ -138,7 +138,7 @@ impl GithubPullRequestOpen for Client {
 
 #[cfg(test)]
 mod tests {
-    use crate::{git::branch_name::RoswaalGitBranchName, language::ast::RoswaalTestSyntax, location::location::RoswaalStringLocations};
+    use crate::{git::branch_name::RoswaalOwnedGitBranchName, language::ast::RoswaalTestSyntax, location::location::RoswaalStringLocations};
 
     use super::GithubPullRequest;
 
@@ -147,7 +147,7 @@ mod tests {
         let pr = GithubPullRequest::for_tif_react_frontend(
             "Hello".to_string(),
             "World".to_string(),
-            RoswaalGitBranchName::new("test-branch")
+            RoswaalOwnedGitBranchName::new("test-branch")
         )
         .for_testing_do_not_merge();
         assert_eq!(pr.title, "[Test - DO NOT MERGE] Roswaal: Hello");
@@ -163,7 +163,7 @@ Test 2, -78.290782973, 54.309983793
 Invalid, hello, world
             ";
         let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
-        let branch_name = RoswaalGitBranchName::new("test-locations-branch");
+        let branch_name = RoswaalOwnedGitBranchName::new("test-locations-branch");
         let pr = GithubPullRequest::for_locations_tif_react_frontend(string_locations, branch_name);
         assert_eq!(pr.title, "Roswaal: Add Locations (Test 1, 908308, Test 2, Invalid)".to_string());
         let expected_body = "Adds the following locations to the acceptance teeeeeeeeeests:
@@ -184,7 +184,7 @@ Test 1, 45.0, 4.0
 Test 2, -78.290782973, 54.309983793
             ";
         let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
-        let branch_name = RoswaalGitBranchName::new("test-locations-branch");
+        let branch_name = RoswaalOwnedGitBranchName::new("test-locations-branch");
         let pr = GithubPullRequest::for_locations_tif_react_frontend(string_locations, branch_name);
         assert_eq!(pr.title, "Roswaal: Add Locations (Test 1, Test 2)".to_string());
         let expected_body = "Adds the following locations to the acceptance teeeeeeeeeests:
@@ -213,7 +213,7 @@ Requirement 1: B";
         ];
         let pr = GithubPullRequest::for_test_cases_tif_react_frontend(
             tests_with_names,
-            RoswaalGitBranchName::new("test-cases")
+            RoswaalOwnedGitBranchName::new("test-cases")
         );
         assert_eq!(pr.title, "Roswaal: Add Tests \"I am the test\", \"I am the next test\"");
         let expected_body = "Adds the following teeeeeests!

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1,0 +1,193 @@
+use anyhow::Result;
+use std::{path::Path, sync::Arc};
+use git2::{build::CheckoutBuilder, Cred, FetchOptions, IndexAddOption, PushOptions, RemoteCallbacks, Repository};
+use tokio::sync::{Mutex, MutexGuard};
+
+use super::{branch_name::RoswaalOwnedGitBranchName, metadata::RoswaalGitRepositoryMetadata};
+
+/// A wrapper for a git repository that serializes access to an underlying git client.
+pub struct RoswaalGitRepository<Client> {
+    mutex: Arc<Mutex<Client>>
+}
+
+impl <Client> RoswaalGitRepository<Client>
+    where Client: RoswaalGitRepositoryClient {
+    /// Attempts to open a repository with the specified metadata.
+    pub async fn open(metadata: &RoswaalGitRepositoryMetadata) -> Result<Self> {
+        let client = Client::try_new(metadata).await?;
+        Ok(Self { mutex: Arc::new(Mutex::new(client)) })
+    }
+}
+
+pub type RoswaalGitRepositoryTransaction<'a, Client> = MutexGuard<'a, Client>;
+
+impl <Client> RoswaalGitRepository<Client>
+    where Client: RoswaalGitRepositoryClient {
+    /// Starts a transaction to this repository.
+    pub async fn transaction(&self) -> RoswaalGitRepositoryTransaction<Client> {
+        self.mutex.lock().await
+    }
+}
+
+/// A git client trait.
+pub trait RoswaalGitRepositoryClient: Sized {
+    /// Attempts to create this client from metadata.
+    async fn try_new(metadata: &RoswaalGitRepositoryMetadata) -> Result<Self>;
+
+    /// Performs the equivalent of a `git switch <branch>`.
+    async fn switch_branch(&self, name: &str) -> Result<()>;
+
+    /// Performs the equivalent of a `git pull origin <branch>`.
+    async fn pull_branch(&self, name: &str) -> Result<()>;
+
+    /// Performs the equivalent of a `git commit -am <message>`.
+    async fn commit_all(&self, message: &str) -> Result<()>;
+
+    /// Performs the equivalent of a `git checkout -b <branch>`.
+    async fn checkout_new_branch(&self, name: &RoswaalOwnedGitBranchName) -> Result<()>;
+
+    /// Peforms the equivalent of a `git push origin <branch>`.
+    async fn push_changes(&self, branch_name: &RoswaalOwnedGitBranchName) -> Result<()>;
+}
+
+/// A `RoswaalGitRepositoryClient` implementation using lib2git and the git2 crate.
+pub struct LibGit2RepositoryClient {
+    repo: Repository,
+    metadata: RoswaalGitRepositoryMetadata
+}
+
+impl RoswaalGitRepositoryClient for LibGit2RepositoryClient {
+    async fn try_new(metadata: &RoswaalGitRepositoryMetadata) -> Result<Self> {
+        let repo = Repository::open(metadata.relative_path("."))?;
+        Ok(Self { repo, metadata: metadata.clone() })
+    }
+
+    async fn switch_branch(&self, name: &str) -> Result<()> {
+        self.repo.set_head(&format!("refs/heads/{}", name))?;
+        let mut checkout_builder = CheckoutBuilder::new();
+        self.repo.checkout_head(Some(&mut checkout_builder.force()))?;
+        Ok(())
+    }
+
+    async fn pull_branch(&self, name: &str) -> Result<()> {
+        let mut remote = self.repo.find_remote("origin")?;
+        let mut fetch_options = FetchOptions::new();
+        fetch_options.remote_callbacks(self.remote_callbacks());
+        remote.fetch(&[name], Some(&mut fetch_options), None)?;
+        let fetch_head = self.repo.find_reference("FETCH_HEAD")?;
+        let fetch_commit = self.repo.reference_to_annotated_commit(&fetch_head)?;
+        self.repo.merge(&[&fetch_commit], None, None)?;
+        Ok(())
+    }
+
+    async fn commit_all(&self, message: &str) -> Result<()> {
+        let mut index = self.repo.index()?;
+        index.add_all(["*"].iter(), IndexAddOption::DEFAULT, None)?;
+        index.write()?;
+        let oid = index.write_tree()?;
+        let signature = self.repo.signature()?;
+        let parent_commit = self.repo.head()?.peel_to_commit()?;
+        let tree = self.repo.find_tree(oid)?;
+        self.repo.commit(Some("HEAD"), &signature, &signature, message, &tree, &[&parent_commit])?;
+        Ok(())
+    }
+
+    async fn checkout_new_branch(&self, name: &RoswaalOwnedGitBranchName) -> Result<()> {
+        let commit = self.repo.head()?.peel_to_commit()?;
+        _ = self.repo.branch(&name.to_string(), &commit, false)?;
+        let (object, reference) = self.repo.revparse_ext(&name.to_string())?;
+        self.repo.checkout_tree(&object, None)?;
+        if let Some(name) = reference.and_then(|r| r.name().map(|s| s.to_string())) {
+            self.repo.set_head(&name)?;
+        }
+        Ok(())
+    }
+
+    async fn push_changes(&self, branch_name: &RoswaalOwnedGitBranchName) -> Result<()> {
+        let mut remote = self.repo.find_remote("origin")?;
+        let mut push_options = PushOptions::new();
+        push_options.remote_callbacks(self.remote_callbacks());
+        remote.push(&[format!("refs/heads/{}", branch_name.to_string())], Some(&mut push_options))?;
+        Ok(())
+    }
+}
+
+impl LibGit2RepositoryClient {
+    fn remote_callbacks(&self) -> RemoteCallbacks {
+        let mut callbacks = RemoteCallbacks::new();
+        callbacks.credentials(|_, user, _| {
+            let private_key_path = self.metadata.ssh_private_key_path();
+            Cred::ssh_key(user.unwrap(), None, Path::new(&private_key_path), None)
+        });
+        callbacks
+    }
+}
+
+/// A `RoswaalGitRepositoryClient` implementation suitable for test-stubbing.
+#[cfg(test)]
+pub struct TestGitRepositoryClient;
+
+#[cfg(test)]
+impl RoswaalGitRepositoryClient for TestGitRepositoryClient {
+    async fn try_new(metadata: &RoswaalGitRepositoryMetadata) -> Result<Self> {
+        Ok(Self)
+    }
+
+    async fn switch_branch(&self, name: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn pull_branch(&self, name: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn commit_all(&self, message: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn checkout_new_branch(&self, name: &RoswaalOwnedGitBranchName) -> Result<()> {
+        Ok(())
+    }
+
+    async fn push_changes(&self, branch_name: &RoswaalOwnedGitBranchName) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::{fs::File, io::{AsyncReadExt, AsyncWriteExt}};
+
+    use crate::{git::{branch_name::RoswaalOwnedGitBranchName, metadata::RoswaalGitRepositoryMetadata, repo::RoswaalGitRepository}, utils::test_support::reset_test_repo};
+
+    #[tokio::test]
+    async fn test_add_commit_push_pull() {
+        reset_test_repo().await.unwrap();
+        let metadata = RoswaalGitRepositoryMetadata::for_testing();
+        let repo = RoswaalGitRepository::<LibGit2RepositoryClient>::open(&metadata).await.unwrap();
+        let transaction = repo.transaction().await;
+        let branch_name = RoswaalOwnedGitBranchName::new("test");
+        transaction.checkout_new_branch(&branch_name).await.unwrap();
+
+        let expected_file_contents = "In this world, all life will walk towards the future, hand in hand.";
+        let mut file = File::create(metadata.relative_path("test.txt")).await.unwrap();
+        file.write(expected_file_contents.as_bytes()).await.unwrap();
+        file.flush().await.unwrap();
+        drop(file);
+
+        transaction.commit_all("I like this!").await.unwrap();
+        transaction.push_changes(&branch_name).await.unwrap();
+        transaction.switch_branch(metadata.base_branch_name()).await.unwrap();
+
+        assert!(File::open(metadata.relative_path("test.txt")).await.is_err());
+
+        transaction.pull_branch(&branch_name.to_string()).await.unwrap();
+
+        file = File::open(metadata.relative_path("test.txt")).await.unwrap();
+        let mut file_contents = String::new();
+        file.read_to_string(&mut file_contents).await.unwrap();
+
+        assert_eq!(file_contents, expected_file_contents)
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,4 @@ pub mod string;
 pub mod is_case;
 pub mod normalize;
 pub mod sqlite;
+pub mod test_support;

--- a/src/utils/test_support.rs
+++ b/src/utils/test_support.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+use anyhow::Result;
+#[cfg(test)]
+use tokio::process::Command;
+
+/// Resets the test repo for testing purposes.
+#[cfg(test)]
+pub async fn reset_test_repo() -> Result<()> {
+    Command::new("./setup_test_repo.sh").spawn()?.wait().await?;
+    Ok(())
+}


### PR DESCRIPTION
Implements a git client using lib2git and the git2 crate.

2 goals needed to be fulfilled here:
1. lib2git is not thread-safe, so all interactions must be serialized.
2. lib2git provides low-level methods for interacting with the git database (eg. no direct equivalent for common git commands like `git switch <branch>`), so I needed a higher-level interface to represent common git commands.

To achieve this, I made a trait called `RoswaalGitRepositoryClient` with high-level requirements equivalent to common git commands. I then wrap an instance of the trait in the `RoswaalGitRepository` struct which serializes access to the client. Each git client must be constructible from a `RoswaalGitRepositoryMetadata` instance.

The `push_changes` and `checkout_new_branch` methods require a `RoswaalOwnedGitBranchName` instance instead of a typical string branch name. The reason for this goes back to #11 where I specified why unique branch names are needed. The `switch_branch` and `pull_branch` methods only require a typical string because we may need to pull from branches not created by the tool (eg. `development` ).

I also made all the methods of the trait `async`. While technically not needed because git2 does not use a synchronous interface, it does allow for better code evolution of operations which *should* be async.

The primary implementation of the `RoswaalGitRepositoryClient` trait is the `LibGit2RepositoryClient` struct. This client holds onto a metadata instance and a git2 `Repository` instance. The metadata is needed since it holds the path to the private ssh key needed to push changes to remote repositories. Each time we need to push or pull changes, we need to construct a `RemoteCallbacks` instance which is configured with ssh credentials.

I wrote a singular integration test for this client which goes through a typical checkout, edit, add, commit, push, switch, and pull flow. For now, this is fine, but there may be a need to handle specific git errors like merge conflicts.

There is a test implementation of the git client trait, this will make it easier to mock failure results, and/or ignore git-related things in tests that do not care about the git integration. For now, this implementation is empty.

Lastly, I renamed some things and split the test repo initialization into a separate shell script. Tests must reset the test repo on each run to ensure a fresh state. For that, I have a test support file in `utils` that includes a function to run the shell script that resets the state of the test repo.