### PR TITLE
Small Cleanup

### DIFF
--- a/src/git/edit.rs
+++ b/src/git/edit.rs
@@ -57,7 +57,7 @@ mod tests {
     use tokio::fs::{try_exists, File};
 
     use super::*;
-    use crate::git::{metadata::RoswaalGitRepositoryMetadata, repo::{LibGit2RepositoryClient, PullBranchStatus}, test_support::{repo_with_test_metadata, write_string, TestGithubPullRequestOpen, with_clean_test_repo_access}};
+    use crate::git::{metadata::RoswaalGitRepositoryMetadata, repo::{LibGit2RepositoryClient, PullBranchStatus, RoswaalGitRepository}, test_support::{repo_with_test_metadata, with_clean_test_repo_access, write_string, TestGithubPullRequestOpen}};
 
     #[tokio::test]
     async fn test_basic_flow_returns_successfully_with_proper_pr_opened_and_correct_repo_state() {

--- a/src/operations/add_locations.rs
+++ b/src/operations/add_locations.rs
@@ -3,12 +3,12 @@ use anyhow::Result;
 use crate::{location::location::RoswaalStringLocations, utils::sqlite::RoswaalSqlite, with_transaction};
 
 #[derive(Debug, PartialEq)]
-pub enum AddLocationsResult {
+pub enum AddLocationsStatus {
     Success(RoswaalStringLocations),
     NoLocationsAdded
 }
 
-impl AddLocationsResult {
+impl AddLocationsStatus {
     pub async fn from_adding_locations(
         locations_str: &str,
         sqlite: &RoswaalSqlite
@@ -27,30 +27,30 @@ impl AddLocationsResult {
 
 #[cfg(test)]
 mod tests {
-    use crate::{location::location::RoswaalStringLocations, operations::add_locations::AddLocationsResult, utils::sqlite::RoswaalSqlite};
+    use crate::{location::location::RoswaalStringLocations, operations::add_locations::AddLocationsStatus, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn test_success_when_adding_locations_smoothly() {
         let str = "Test, 50.0, 50.0";
         let sqlite = RoswaalSqlite::in_memory().await.unwrap();
-        let result = AddLocationsResult::from_adding_locations(str, &sqlite).await;
+        let result = AddLocationsStatus::from_adding_locations(str, &sqlite).await;
         let str_locations = RoswaalStringLocations::from_roswaal_locations_str(str);
-        assert_eq!(result.ok(), Some(AddLocationsResult::Success(str_locations)))
+        assert_eq!(result.ok(), Some(AddLocationsStatus::Success(str_locations)))
     }
 
     #[tokio::test]
     async fn test_success_mixes_proper_and_invalid_locations() {
         let str = "Test, 50.0, 50.0\n29879";
         let sqlite = RoswaalSqlite::in_memory().await.unwrap();
-        let result = AddLocationsResult::from_adding_locations(str, &sqlite).await;
+        let result = AddLocationsStatus::from_adding_locations(str, &sqlite).await;
         let str_locations = RoswaalStringLocations::from_roswaal_locations_str(str);
-        assert_eq!(result.ok(), Some(AddLocationsResult::Success(str_locations)))
+        assert_eq!(result.ok(), Some(AddLocationsStatus::Success(str_locations)))
     }
 
     #[tokio::test]
     async fn test_no_locations_added_when_empty_vector() {
         let sqlite = RoswaalSqlite::in_memory().await.unwrap();
-        let result = AddLocationsResult::from_adding_locations("", &sqlite).await;
-        assert_eq!(result.ok(), Some(AddLocationsResult::NoLocationsAdded))
+        let result = AddLocationsStatus::from_adding_locations("", &sqlite).await;
+        assert_eq!(result.ok(), Some(AddLocationsStatus::NoLocationsAdded))
     }
 }

--- a/src/operations/load_all_locations.rs
+++ b/src/operations/load_all_locations.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use crate::{location::location::RoswaalLocation, utils::sqlite::RoswaalSqlite, with_transaction};
 
 #[derive(Debug, PartialEq)]
-pub enum LoadAllLocationsResult {
+pub enum LoadAllLocationsStatus {
     Success(Vec<RoswaalLocation>),
     NoLocations
 }
 
-impl LoadAllLocationsResult {
+impl LoadAllLocationsStatus {
     pub async fn from_stored_locations(
         sqlite: &RoswaalSqlite
     ) -> Result<Self> {
@@ -26,13 +26,13 @@ impl LoadAllLocationsResult {
 
 #[cfg(test)]
 mod tests {
-    use crate::{location::location::RoswaalLocation, operations::{add_locations::AddLocationsResult, load_all_locations::LoadAllLocationsResult}, utils::sqlite::RoswaalSqlite};
+    use crate::{location::location::RoswaalLocation, operations::{add_locations::AddLocationsStatus, load_all_locations::LoadAllLocationsStatus}, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn test_returns_no_locations_when_no_saved_locations() {
         let sqlite = RoswaalSqlite::in_memory().await.unwrap();
-        let result = LoadAllLocationsResult::from_stored_locations(&sqlite).await.unwrap();
-        assert_eq!(result, LoadAllLocationsResult::NoLocations)
+        let status = LoadAllLocationsStatus::from_stored_locations(&sqlite).await.unwrap();
+        assert_eq!(status, LoadAllLocationsStatus::NoLocations)
     }
 
     #[tokio::test]
@@ -47,8 +47,8 @@ Test 1, 50.0, 50.0
 Invalid
 Test 2, -5.0, 5.0
             ";
-        _ = AddLocationsResult::from_adding_locations(&locations_str, &sqlite).await.unwrap();
-        let result = LoadAllLocationsResult::from_stored_locations(&sqlite).await.unwrap();
-        assert_eq!(result, LoadAllLocationsResult::Success(locations))
+        _ = AddLocationsStatus::from_adding_locations(&locations_str, &sqlite).await.unwrap();
+        let status = LoadAllLocationsStatus::from_stored_locations(&sqlite).await.unwrap();
+        assert_eq!(status, LoadAllLocationsStatus::Success(locations))
     }
 }


### PR DESCRIPTION
- Use `Status` suffix instead of `Result` suffix for types in the `operations` module.
- Fix a test compilation error.