### PR TITLE
Add Branch Name To Stored Locations

### DIFF
--- a/src/git/branch_name.rs
+++ b/src/git/branch_name.rs
@@ -1,22 +1,27 @@
 use nanoid::nanoid;
+use sqlx::{sqlite::SqliteTypeInfo, Decode, Sqlite, Type};
 
 /// A type for a git branch name that is created by roswaal.
 ///
 /// Each branch name contains a 10 character nano id as its suffix in order to make each instance
 /// unique. This uniqueness ensures that duplicate branch names do not clash with each other.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct RoswaalOwnedGitBranchName {
-    raw_name: String
-}
+#[derive(Debug, PartialEq, Eq, Clone, Decode)]
+pub struct RoswaalOwnedGitBranchName(String);
 
 impl RoswaalOwnedGitBranchName {
     pub fn new(name: &str) -> Self {
-        Self { raw_name: format!("roswaal-{}-{}", name, nanoid!(10)) }
+        Self(format!("roswaal-{}-{}", name, nanoid!(10)))
     }
 }
 
 impl ToString for RoswaalOwnedGitBranchName {
     fn to_string(&self) -> String {
-        self.raw_name.clone()
+        self.0.clone()
+    }
+}
+
+impl Type<Sqlite> for RoswaalOwnedGitBranchName {
+    fn type_info() -> SqliteTypeInfo {
+        <String as Type<Sqlite>>::type_info()
     }
 }

--- a/src/location/storage.rs
+++ b/src/location/storage.rs
@@ -1,16 +1,47 @@
 use anyhow::Result;
-use sqlx::{prelude::FromRow, query, query_as, Sqlite};
+use sqlx::{query, query_as, FromRow, Sqlite};
 
-use crate::utils::sqlite::RoswaalSqliteTransaction;
+use crate::{git::branch_name::RoswaalOwnedGitBranchName, utils::sqlite::RoswaalSqliteTransaction};
 
 use super::location::RoswaalLocation;
 
+#[derive(Debug, PartialEq)]
+pub struct RoswaalStoredLocation {
+    location: RoswaalLocation,
+    branch_name: Option<RoswaalOwnedGitBranchName>
+}
+
+impl RoswaalStoredLocation {
+    pub fn location(&self) -> &RoswaalLocation {
+        &self.location
+    }
+
+    pub fn branch_name(&self) -> Option<&RoswaalOwnedGitBranchName> {
+        self.branch_name.as_ref()
+    }
+}
+
+const SAVE_STATEMENT: &str = "
+INSERT INTO Locations (
+    latitude,
+    longitude,
+    name,
+    unmerged_branch_name
+) VALUES (
+    ?,
+    ?,
+    ?,
+    ?
+);";
+
 impl <'a> RoswaalSqliteTransaction <'a> {
-    pub async fn save_locations(&mut self, locations: &Vec<RoswaalLocation>) -> Result<()> {
+    pub async fn save_locations(
+        &mut self,
+        locations: &Vec<RoswaalLocation>,
+        branch_name: &RoswaalOwnedGitBranchName
+    ) -> Result<()> {
         let statements = locations.iter()
-            .map(|_| {
-                "INSERT OR REPLACE INTO Locations (latitude, longitude, name) VALUES (?, ?, ?);"
-            })
+            .map(|_| SAVE_STATEMENT)
             .collect::<Vec<&str>>()
             .join("\n");
         let mut bulk_insert_query = query::<Sqlite>(&statements);
@@ -18,19 +49,23 @@ impl <'a> RoswaalSqliteTransaction <'a> {
             bulk_insert_query = bulk_insert_query.bind(location.coordinate().latitude())
                 .bind(location.coordinate().longitude())
                 .bind(&location.name().raw_value)
+                .bind(branch_name.to_string())
         }
         bulk_insert_query.execute(self.connection()).await?;
         Ok(())
     }
 
-    pub async fn locations_in_alphabetical_order(&mut self) -> Result<Vec<RoswaalLocation>> {
+    pub async fn locations_in_alphabetical_order(&mut self) -> Result<Vec<RoswaalStoredLocation>> {
         let locations = query_as::<Sqlite, SqliteLocation>(
-            "SELECT * FROM Locations ORDER BY name"
+            "SELECT * FROM Locations ORDER BY name, latitude"
         )
         .fetch_all(self.connection())
         .await?
         .iter()
-        .map(|l| RoswaalLocation::new_without_validation(&l.name, l.latitude, l.longitude))
+        .map(|l| RoswaalStoredLocation {
+            location: RoswaalLocation::new_without_validation(&l.name, l.latitude, l.longitude),
+            branch_name: l.unmerged_branch_name.clone()
+        })
         .collect();
         Ok(locations)
     }
@@ -40,48 +75,83 @@ impl <'a> RoswaalSqliteTransaction <'a> {
 struct SqliteLocation {
     latitude: f32,
     longitude: f32,
-    name: String
+    name: String,
+    unmerged_branch_name: Option<RoswaalOwnedGitBranchName>
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{location::location::RoswaalLocation, utils::sqlite::RoswaalSqlite};
+    use crate::{git::branch_name::{self, RoswaalOwnedGitBranchName}, location::{location::RoswaalLocation, storage::RoswaalStoredLocation}, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn test_add_and_load_locations_no_prior_locations() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test");
         let sqlite = RoswaalSqlite::in_memory().await.unwrap();
         let mut transaction = sqlite.transaction().await.unwrap();
         let locations = vec![
             RoswaalLocation::new_without_validation("Antarctica", 32.29873932, 122.3939839),
             RoswaalLocation::new_without_validation("New York", 45.0, 45.0)
         ];
-        _ = transaction.save_locations(&locations).await;
+        _ = transaction.save_locations(&locations, &branch_name).await;
         let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
-        assert_eq!(locations, saved_locations)
+        let expected_locations = vec![
+            RoswaalStoredLocation { location: locations[0].clone(), branch_name: Some(branch_name.clone()) },
+            RoswaalStoredLocation { location: locations[1].clone(), branch_name: Some(branch_name.clone()) }
+        ];
+        assert_eq!(saved_locations, expected_locations)
     }
 
     #[tokio::test]
-    async fn test_add_and_load_locations_upserts_prior_locations() {
+    async fn test_add_same_locations_on_same_branch_throws_error() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test");
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
+        let mut locations = vec![
+            RoswaalLocation::new_without_validation("Antarctica", 32.29873932, 122.3939839)
+        ];
+        _ = transaction.save_locations(&locations, &branch_name).await;
+        locations = vec![
+            RoswaalLocation::new_without_validation("Antarctica", 45.20982, 78.209782972)
+        ];
+        let result = transaction.save_locations(&locations, &branch_name).await;
+        assert!(result.is_err())
+    }
+
+    #[tokio::test]
+    async fn test_add_and_load_locations_on_different_branches_adds_new_record() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test");
         let sqlite = RoswaalSqlite::in_memory().await.unwrap();
         let mut transaction = sqlite.transaction().await.unwrap();
         let mut locations = vec![
             RoswaalLocation::new_without_validation("Antarctica", 32.29873932, 122.3939839),
             RoswaalLocation::new_without_validation("New York", 45.0, 45.0)
         ];
-        _ = transaction.save_locations(&locations).await;
+        _ = transaction.save_locations(&locations, &branch_name).await;
         locations = vec![
             RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0),
             RoswaalLocation::new_without_validation("Oakland", 45.0, 45.0)
         ];
-        _ = transaction.save_locations(&locations).await;
+        let branch_name2 = RoswaalOwnedGitBranchName::new("test-2");
+        _ = transaction.save_locations(&locations, &branch_name2).await;
         let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
-        assert_eq!(
-            saved_locations,
-            vec![
-                RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0),
-                RoswaalLocation::new_without_validation("New York", 45.0, 45.0),
-                RoswaalLocation::new_without_validation("Oakland", 45.0, 45.0)
-            ]
-        )
+        let expected_locations = vec![
+            RoswaalStoredLocation {
+                location: RoswaalLocation::new_without_validation("Antarctica", 32.29873932, 122.3939839),
+                branch_name: Some(branch_name.clone())
+            },
+            RoswaalStoredLocation {
+                location: RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0),
+                branch_name: Some(branch_name2.clone())
+            },
+            RoswaalStoredLocation {
+                location: RoswaalLocation::new_without_validation("New York", 45.0, 45.0),
+                branch_name: Some(branch_name.clone())
+            },
+            RoswaalStoredLocation {
+                location: RoswaalLocation::new_without_validation("Oakland", 45.0, 45.0),
+                branch_name: Some(branch_name2.clone())
+            }
+        ];
+        assert_eq!(saved_locations, expected_locations)
     }
 }

--- a/src/operations/add_locations.rs
+++ b/src/operations/add_locations.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::{location::location::RoswaalStringLocations, utils::sqlite::RoswaalSqlite, with_transaction};
+use crate::{git::branch_name::{self, RoswaalOwnedGitBranchName}, location::location::RoswaalStringLocations, utils::sqlite::RoswaalSqlite, with_transaction};
 
 #[derive(Debug, PartialEq)]
 pub enum AddLocationsStatus {
@@ -19,7 +19,8 @@ impl AddLocationsStatus {
         let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
         let mut transaction = sqlite.transaction().await?;
         with_transaction!(transaction, async {
-            transaction.save_locations(&string_locations.locations()).await?;
+            let branch_name = RoswaalOwnedGitBranchName::new("test");
+            transaction.save_locations(&string_locations.locations(), &branch_name).await?;
             Ok(Self::Success(string_locations))
         })
     }

--- a/src/operations/add_locations.rs
+++ b/src/operations/add_locations.rs
@@ -19,7 +19,7 @@ impl AddLocationsStatus {
         let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
         let mut transaction = sqlite.transaction().await?;
         with_transaction!(transaction, async {
-            let branch_name = RoswaalOwnedGitBranchName::new("test");
+            let branch_name = RoswaalOwnedGitBranchName::new("add-locations");
             transaction.save_locations(&string_locations.locations(), &branch_name).await?;
             Ok(Self::Success(string_locations))
         })

--- a/src/operations/load_all_locations.rs
+++ b/src/operations/load_all_locations.rs
@@ -17,7 +17,7 @@ impl LoadAllLocationsStatus {
                 if locations.is_empty() {
                     Self::NoLocations
                 } else {
-                    Self::Success(locations)
+                    Self::Success(locations.iter().map(|l| l.location().clone()).collect())
                 }
             })
         })

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -30,7 +30,9 @@ CREATE TABLE IF NOT EXISTS Locations (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     latitude DOUBLE NOT NULL,
     longitude DOUBLE NOT NULL,
-    name TEXT NOT NULL UNIQUE
+    name TEXT NOT NULL,
+    unmerged_branch_name TEXT,
+    UNIQUE(name, unmerged_branch_name)
 )
             "
         )


### PR DESCRIPTION
When saving new locations (or tests), nothing is official until the PR is merged on github. The tool should recognize this, and I've added an `unmerged_branch_name` field to the Locations table in the database. Once the PR for saving new locations is merged, then we can null that field.