### PR TITLE
Branch Name Equality Comparisons

### DIFF
--- a/src/git/branch_name.rs
+++ b/src/git/branch_name.rs
@@ -12,6 +12,49 @@ impl RoswaalOwnedGitBranchName {
     pub fn new(name: &str) -> Self {
         Self(format!("roswaal-{}-{}", name, nanoid!(10)))
     }
+
+    pub fn for_adding_tests() -> Self {
+        Self::new("add-tests")
+    }
+
+    pub fn for_removing_tests() -> Self {
+        Self::new("remove-tests")
+    }
+
+    pub fn for_adding_locations() -> Self {
+        Self::new("add-locations")
+    }
+
+    pub fn for_removing_locations() -> Self {
+        Self::new("remove-locations")
+    }
+}
+
+impl RoswaalOwnedGitBranchName {
+    /// Returns true if the branch's base name is the specifed name.
+    ///
+    /// This check does not include any special characters added by this type that can be found
+    /// in the `.to_string()` output.
+    pub fn is_named(&self, name: &str) -> bool {
+        let (start, end) = (8, self.0.len() - 11);
+        &self.0[start..end] == name
+    }
+
+    pub fn is_for_adding_tests(&self) -> bool {
+        self.is_named("add-tests")
+    }
+
+    pub fn is_for_removing_tests(&self) -> bool {
+        self.is_named("remove-tests")
+    }
+
+    pub fn is_for_adding_locations(&self) -> bool {
+        self.is_named("add-locations")
+    }
+
+    pub fn is_for_removing_locations(&self) -> bool {
+        self.is_named("remove-locations")
+    }
 }
 
 impl ToString for RoswaalOwnedGitBranchName {
@@ -23,5 +66,22 @@ impl ToString for RoswaalOwnedGitBranchName {
 impl Type<Sqlite> for RoswaalOwnedGitBranchName {
     fn type_info() -> SqliteTypeInfo {
         <String as Type<Sqlite>>::type_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RoswaalOwnedGitBranchName;
+
+    #[test]
+    fn test_is_named() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test-branch");
+        let nanoid = &branch_name.to_string()[branch_name.to_string().len() - 10..];
+        assert!(!branch_name.is_named("roswaal"));
+        assert!(!branch_name.is_named(nanoid));
+        assert!(!branch_name.is_named("-"));
+        assert!(!branch_name.is_named("test"));
+        assert!(!branch_name.is_named("branch"));
+        assert!(branch_name.is_named("test-branch"));
     }
 }

--- a/src/operations/add_locations.rs
+++ b/src/operations/add_locations.rs
@@ -19,7 +19,7 @@ impl AddLocationsStatus {
         let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
         let mut transaction = sqlite.transaction().await?;
         with_transaction!(transaction, async {
-            let branch_name = RoswaalOwnedGitBranchName::new("add-locations");
+            let branch_name = RoswaalOwnedGitBranchName::for_adding_locations();
             transaction.save_locations(&string_locations.locations(), &branch_name).await?;
             Ok(Self::Success(string_locations))
         })


### PR DESCRIPTION
Part of the "merge" process will need to know what kind of merge the branch is for. We can achieve this by putting the purpose of the branch in its name, and then comparing against that when deciding whether or not we need to merge locations or tests when calling the merge endpoint.