### PR TITLE
Basic Tests Storage

### DIFF
--- a/src/git/branch_name.rs
+++ b/src/git/branch_name.rs
@@ -12,6 +12,49 @@ impl RoswaalOwnedGitBranchName {
     pub fn new(name: &str) -> Self {
         Self(format!("roswaal-{}-{}", name, nanoid!(10)))
     }
+
+    pub fn for_adding_tests() -> Self {
+        Self::new("add-tests")
+    }
+
+    pub fn for_removing_tests() -> Self {
+        Self::new("remove-tests")
+    }
+
+    pub fn for_adding_locations() -> Self {
+        Self::new("add-locations")
+    }
+
+    pub fn for_removing_locations() -> Self {
+        Self::new("remove-locations")
+    }
+}
+
+impl RoswaalOwnedGitBranchName {
+    /// Returns true if the branch's base name is the specifed name.
+    ///
+    /// This check does not include any special characters added by this type that can be found
+    /// in the `.to_string()` output.
+    pub fn is_named(&self, name: &str) -> bool {
+        let (start, end) = (8, self.0.len() - 11);
+        &self.0[start..end] == name
+    }
+
+    pub fn is_for_adding_tests(&self) -> bool {
+        self.is_named("add-tests")
+    }
+
+    pub fn is_for_removing_tests(&self) -> bool {
+        self.is_named("remove-tests")
+    }
+
+    pub fn is_for_adding_locations(&self) -> bool {
+        self.is_named("add-locations")
+    }
+
+    pub fn is_for_removing_locations(&self) -> bool {
+        self.is_named("remove-locations")
+    }
 }
 
 impl ToString for RoswaalOwnedGitBranchName {
@@ -23,5 +66,22 @@ impl ToString for RoswaalOwnedGitBranchName {
 impl Type<Sqlite> for RoswaalOwnedGitBranchName {
     fn type_info() -> SqliteTypeInfo {
         <String as Type<Sqlite>>::type_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RoswaalOwnedGitBranchName;
+
+    #[test]
+    fn test_is_named() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test-branch");
+        let nanoid = &branch_name.to_string()[branch_name.to_string().len() - 10..];
+        assert!(!branch_name.is_named("roswaal"));
+        assert!(!branch_name.is_named(nanoid));
+        assert!(!branch_name.is_named("-"));
+        assert!(!branch_name.is_named("test"));
+        assert!(!branch_name.is_named("branch"));
+        assert!(branch_name.is_named("test-branch"));
     }
 }

--- a/src/language/test.rs
+++ b/src/language/test.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::location::name::RoswaalLocationName;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -25,9 +27,13 @@ impl RoswaalTest {
     pub fn commands(&self) -> &Vec<RoswaalTestCommand> {
         &self.commands
     }
+
+    pub fn description(&self) -> Option<&String> {
+        self.description.as_ref()
+    }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum RoswaalTestCommand {
     Step { name: String, requirement: String },
     SetLocation { location_name: RoswaalLocationName }

--- a/src/language/test.rs
+++ b/src/language/test.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::location::name::RoswaalLocationName;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RoswaalTest {
     name: String,
     description: Option<String>,

--- a/src/location/name.rs
+++ b/src/location/name.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use once_cell::sync::Lazy;
 use regex::{Regex, RegexBuilder};
+use serde::{Deserialize, Serialize};
 
 use crate::utils::{normalize::RoswaalNormalize, string::UppercaseFirstAsciiCharacter};
 
@@ -20,7 +21,7 @@ pub type RoswaalLocationParsingResult = Result<
 ///
 /// This type contains helpers for matching the name against a query, and
 /// for formatting the name in different contexts.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct RoswaalLocationName {
     pub(super) raw_value: String
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod generation;
 mod location;
 mod git;
 mod operations;
+mod tests_data;
 
 fn main() {
     println!("Hello, world!");

--- a/src/operations/add_locations.rs
+++ b/src/operations/add_locations.rs
@@ -19,7 +19,7 @@ impl AddLocationsStatus {
         let string_locations = RoswaalStringLocations::from_roswaal_locations_str(locations_str);
         let mut transaction = sqlite.transaction().await?;
         with_transaction!(transaction, async {
-            let branch_name = RoswaalOwnedGitBranchName::new("add-locations");
+            let branch_name = RoswaalOwnedGitBranchName::for_adding_locations();
             transaction.save_locations(&string_locations.locations(), &branch_name).await?;
             Ok(Self::Success(string_locations))
         })

--- a/src/tests_data/mod.rs
+++ b/src/tests_data/mod.rs
@@ -1,0 +1,2 @@
+pub mod progress;
+pub mod storage;

--- a/src/tests_data/progress.rs
+++ b/src/tests_data/progress.rs
@@ -1,0 +1,19 @@
+use serde::Deserialize;
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct RoswaalTestProgress {
+    test_name: String,
+    results: Vec<RoswaalTestProgressResult>,
+    error: Option<RoswaalTestProgressErrorDescription>
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct RoswaalTestProgressErrorDescription {
+    message: String,
+    stack_trace: String
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+pub struct RoswaalTestProgressResult {
+    did_pass: bool
+}

--- a/src/tests_data/storage.rs
+++ b/src/tests_data/storage.rs
@@ -1,0 +1,281 @@
+use std::iter::zip;
+
+use crate::{git::branch_name::RoswaalOwnedGitBranchName, language::test::{RoswaalTest, RoswaalTestCommand}, utils::sqlite::RoswaalSqliteTransaction};
+use anyhow::Result;
+use sqlx::{query, query_as, FromRow, Sqlite};
+
+use super::progress::RoswaalTestProgressErrorDescription;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RoswaalStoredTest {
+    name: String,
+    description: Option<String>,
+    steps: Vec<RoswaalStoredTestCommand>,
+    error: Option<RoswaalTestProgressErrorDescription>,
+    unmerged_branch_name: Option<RoswaalOwnedGitBranchName>
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RoswaalStoredTestCommand {
+    command: RoswaalTestCommand,
+    did_pass: bool
+}
+
+impl <'a> RoswaalSqliteTransaction<'a> {
+    async fn save_tests(
+        &mut self,
+        tests: &Vec<RoswaalTest>,
+        branch_name: &RoswaalOwnedGitBranchName
+    ) -> Result<()> {
+        let statements = tests.iter().map(|_| {
+            "INSERT INTO Tests (name, description, unmerged_branch_name) VALUES (?, ?, ?) RETURNING id;"
+        })
+        .collect::<Vec<&str>>()
+        .join("\n");
+        let mut tests_insert_query = query_as::<Sqlite, SqliteTestIDRow>(&statements);
+        for test in tests.iter() {
+            tests_insert_query = tests_insert_query.bind(test.name())
+                .bind(test.description())
+                .bind(branch_name.to_string());
+        }
+        let id_rows = tests_insert_query.fetch_all(self.connection()).await?;
+        let command_insert_statements = tests.iter()
+            .flat_map(|t| t.commands())
+            .map(|_| {
+                "INSERT INTO TestSteps (test_id, content, unmerged_branch_name) VALUES (?, ?, ?);"
+            })
+            .collect::<Vec<&str>>()
+            .join("\n");
+        let mut commands_insert_query = query::<Sqlite>(&command_insert_statements);
+        for (test, id_row) in zip(tests.iter(), id_rows.iter()) {
+            for command in test.commands() {
+                commands_insert_query = commands_insert_query.bind(id_row.id)
+                    .bind(serde_json::to_string(&command)?)
+                    .bind(branch_name.to_string())
+            }
+        }
+        commands_insert_query.execute(self.connection()).await?;
+        Ok(())
+    }
+
+    async fn tests_in_alphabetical_order(&mut self) -> Result<Vec<RoswaalStoredTest>> {
+        let sqlite_tests = query_as::<Sqlite, SqliteStoredTestRow>(SELECT_TESTS_IN_ALPHABETICAL_ORDER)
+            .fetch_all(self.connection())
+            .await?;
+        if sqlite_tests.is_empty() { return Ok(vec![]) }
+        let mut test = RoswaalStoredTest {
+            name: sqlite_tests[0].test_name.clone(),
+            description: sqlite_tests[0].description.clone(),
+            steps: vec![],
+            unmerged_branch_name: sqlite_tests[0].unmerged_branch_name.clone(),
+            error: None
+        };
+        let mut tests = Vec::<RoswaalStoredTest>::new();
+        for sqlite_test in sqlite_tests {
+            let command = serde_json::from_str::<RoswaalTestCommand>(&sqlite_test.command_content)?;
+            if sqlite_test.is_separate_from(&test) {
+                tests.push(test);
+                test = RoswaalStoredTest {
+                    name: sqlite_test.test_name.clone(),
+                    description: sqlite_test.description.clone(),
+                    steps: vec![RoswaalStoredTestCommand { command, did_pass: sqlite_test.did_pass }],
+                    unmerged_branch_name: sqlite_test.unmerged_branch_name.clone(),
+                    error: None
+                };
+            } else {
+                test.steps.push(RoswaalStoredTestCommand { command, did_pass: sqlite_test.did_pass })
+            };
+        }
+        tests.push(test);
+        Ok(tests)
+    }
+}
+
+const SELECT_TESTS_IN_ALPHABETICAL_ORDER: &str = "
+SELECT
+    t.name AS test_name,
+    t.description,
+    t.unmerged_branch_name,
+    c.content AS command_content,
+    c.did_pass
+FROM Tests t
+INNER JOIN TestSteps c ON t.id = c.test_id
+ORDER BY test_name;
+";
+
+#[derive(Debug, FromRow)]
+struct SqliteTestIDRow {
+    id: i32
+}
+
+#[derive(Debug, FromRow)]
+struct SqliteStoredTestRow {
+    test_name: String,
+    description: Option<String>,
+    unmerged_branch_name: Option<RoswaalOwnedGitBranchName>,
+    command_content: String,
+    did_pass: bool
+}
+
+impl SqliteStoredTestRow {
+    fn is_separate_from(&self, test: &RoswaalStoredTest) -> bool {
+        test.name != self.test_name || test.unmerged_branch_name != self.unmerged_branch_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::{git::branch_name::{self, RoswaalOwnedGitBranchName}, language::test::{RoswaalTest, RoswaalTestCommand}, location::name::RoswaalLocationName, utils::sqlite::RoswaalSqlite};
+
+    #[tokio::test]
+    async fn test_store_and_retrieve_unmerged_tests() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test");
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
+        let tests = vec![
+            RoswaalTest::new(
+                "Test 1".to_string(),
+                None,
+                vec![
+                    RoswaalTestCommand::Step {
+                        name: "Step 1".to_string(),
+                        requirement: "Requirement 1".to_string()
+                    },
+                    RoswaalTestCommand::SetLocation {
+                        location_name: RoswaalLocationName::from_str("test").unwrap()
+                    }
+                ]
+            ),
+            RoswaalTest::new(
+                "Test 2".to_string(),
+                None,
+                vec![
+                    RoswaalTestCommand::Step {
+                        name: "Step A".to_string(),
+                        requirement: "Requirement A".to_string()
+                    }
+                ]
+            )
+        ];
+        transaction.save_tests(&tests, &branch_name).await.unwrap();
+        let stored_tests = transaction.tests_in_alphabetical_order().await.unwrap();
+        let expected_tests = vec![
+            RoswaalStoredTest {
+                name: "Test 1".to_string(),
+                description: None,
+                steps: vec![
+                    RoswaalStoredTestCommand {
+                        command: RoswaalTestCommand::Step {
+                            name: "Step 1".to_string(),
+                            requirement: "Requirement 1".to_string()
+                        },
+                        did_pass: false
+                    },
+                    RoswaalStoredTestCommand {
+                        command: RoswaalTestCommand::SetLocation {
+                            location_name: RoswaalLocationName::from_str("test").unwrap()
+                        },
+                        did_pass: false
+                    }
+                ],
+                error: None,
+                unmerged_branch_name: Some(branch_name.clone())
+            },
+            RoswaalStoredTest {
+                name: "Test 2".to_string(),
+                description: None,
+                steps: vec![
+                    RoswaalStoredTestCommand {
+                        command: RoswaalTestCommand::Step {
+                            name: "Step A".to_string(),
+                            requirement: "Requirement A".to_string()
+                        },
+                        did_pass: false
+                    }
+                ],
+                error: None,
+                unmerged_branch_name: Some(branch_name.clone())
+            }
+        ];
+        assert_eq!(stored_tests, expected_tests)
+    }
+
+    #[tokio::test]
+    async fn test_store_and_retrieve_unmerged_tests_with_same_name_and_different_branches() {
+        let branch_name1 = RoswaalOwnedGitBranchName::new("test");
+        let branch_name2 = RoswaalOwnedGitBranchName::new("test");
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
+        let mut tests = vec![
+            RoswaalTest::new(
+                "Test".to_string(),
+                None,
+                vec![
+                    RoswaalTestCommand::Step {
+                        name: "Step 1".to_string(),
+                        requirement: "Requirement 1".to_string()
+                    }
+                ]
+            )
+        ];
+        transaction.save_tests(&tests, &branch_name1).await.unwrap();
+        tests = vec![
+            RoswaalTest::new(
+                "Test".to_string(),
+                None,
+                vec![
+                    RoswaalTestCommand::Step {
+                        name: "Step A".to_string(),
+                        requirement: "Requirement A".to_string()
+                    }
+                ]
+            )
+        ];
+        transaction.save_tests(&tests, &branch_name2).await.unwrap();
+        let stored_tests = transaction.tests_in_alphabetical_order().await.unwrap();
+        let expected_tests = vec![
+            RoswaalStoredTest {
+                name: "Test".to_string(),
+                description: None,
+                steps: vec![
+                    RoswaalStoredTestCommand {
+                        command: RoswaalTestCommand::Step {
+                            name: "Step 1".to_string(),
+                            requirement: "Requirement 1".to_string()
+                        },
+                        did_pass: false
+                    }
+                ],
+                error: None,
+                unmerged_branch_name: Some(branch_name1.clone())
+            },
+            RoswaalStoredTest {
+                name: "Test".to_string(),
+                description: None,
+                steps: vec![
+                    RoswaalStoredTestCommand {
+                        command: RoswaalTestCommand::Step {
+                            name: "Step A".to_string(),
+                            requirement: "Requirement A".to_string()
+                        },
+                        did_pass: false
+                    }
+                ],
+                error: None,
+                unmerged_branch_name: Some(branch_name2.clone())
+            }
+        ];
+        assert_eq!(stored_tests, expected_tests)
+    }
+
+    #[tokio::test]
+    async fn test_returns_empty_vector_when_no_inserted_tests() {
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
+        let tests = transaction.tests_in_alphabetical_order().await.unwrap();
+        assert_eq!(tests, vec![])
+    }
+}

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS Tests (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
     description TEXT,
-    unmerged_branch_name TEXT
+    unmerged_branch_name TEXT,
+    UNIQUE(name, unmerged_branch_name)
 );
 CREATE TABLE IF NOT EXISTS TestSteps (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -33,7 +33,21 @@ CREATE TABLE IF NOT EXISTS Locations (
     name TEXT NOT NULL,
     unmerged_branch_name TEXT,
     UNIQUE(name, unmerged_branch_name)
-)
+);
+CREATE TABLE IF NOT EXISTS Tests (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    unmerged_branch_name TEXT
+);
+CREATE TABLE IF NOT EXISTS TestSteps (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    test_id INTEGER NOT NULL,
+    content TEXT NOT_NULL,
+    did_pass INT2 NOT NULL DEFAULT FALSE,
+    unmerged_branch_name TEXT,
+    CONSTRAINT fk_test FOREIGN KEY(test_id) REFERENCES Tests(id)
+);
             "
         )
         .execute(pool)


### PR DESCRIPTION
Adds basic storage for the tests. Like locations, each stored test also has its own `unmerged_branch_name` column that will be set to null when merging.

I have not yet implemented storage for the test progress tracking, that will come after merging is done.