### PR TITLE
Merging: Added Locations and Tests

### DIFF
--- a/src/location/storage.rs
+++ b/src/location/storage.rs
@@ -1,23 +1,19 @@
 use anyhow::Result;
 use sqlx::{query, query_as, FromRow, Sqlite};
 
-use crate::{git::branch_name::RoswaalOwnedGitBranchName, utils::sqlite::RoswaalSqliteTransaction};
+use crate::{git::branch_name::{self, RoswaalOwnedGitBranchName}, utils::sqlite::RoswaalSqliteTransaction};
 
 use super::location::RoswaalLocation;
 
 #[derive(Debug, PartialEq)]
 pub struct RoswaalStoredLocation {
     location: RoswaalLocation,
-    branch_name: Option<RoswaalOwnedGitBranchName>
+    unmerged_branch_name: Option<RoswaalOwnedGitBranchName>
 }
 
 impl RoswaalStoredLocation {
     pub fn location(&self) -> &RoswaalLocation {
         &self.location
-    }
-
-    pub fn branch_name(&self) -> Option<&RoswaalOwnedGitBranchName> {
-        self.branch_name.as_ref()
     }
 }
 
@@ -34,7 +30,32 @@ INSERT OR REPLACE INTO Locations (
     ?
 );";
 
+const UPDATE_MERGE_UNMERGED_STATEMENT: &str = "
+DELETE FROM Locations WHERE name = ? AND unmerged_branch_name IS NULL;
+UPDATE Locations SET unmerged_branch_name = NULL WHERE unmerged_branch_name = ? AND name = ?;
+";
+
 impl <'a> RoswaalSqliteTransaction <'a> {
+    pub async fn merge_unmerged_locations(&mut self, branch_name: &RoswaalOwnedGitBranchName) -> Result<()> {
+        let sqlite_location_names = query_as::<Sqlite, SqliteLocationName>(
+            "SELECT name FROM Locations WHERE unmerged_branch_name = ?;"
+        )
+        .bind(branch_name.to_string())
+        .fetch_all(self.connection())
+        .await?;
+        let update_statements = sqlite_location_names.iter().map(|_| UPDATE_MERGE_UNMERGED_STATEMENT)
+            .collect::<Vec<&str>>()
+            .join("\n");
+        let mut update_query = query::<Sqlite>(&update_statements);
+        for sqlite_name in sqlite_location_names.iter() {
+            update_query = update_query.bind(sqlite_name.name.clone())
+                .bind(branch_name.to_string())
+                .bind(sqlite_name.name.clone());
+        }
+        update_query.execute(self.connection()).await?;
+        Ok(())
+    }
+
     pub async fn save_locations(
         &mut self,
         locations: &Vec<RoswaalLocation>,
@@ -64,11 +85,16 @@ impl <'a> RoswaalSqliteTransaction <'a> {
         .iter()
         .map(|l| RoswaalStoredLocation {
             location: RoswaalLocation::new_without_validation(&l.name, l.latitude, l.longitude),
-            branch_name: l.unmerged_branch_name.clone()
+            unmerged_branch_name: l.unmerged_branch_name.clone()
         })
         .collect();
         Ok(locations)
     }
+}
+
+#[derive(FromRow, Debug)]
+struct SqliteLocationName {
+    name: String
 }
 
 #[derive(FromRow, Clone)]
@@ -95,8 +121,8 @@ mod tests {
         _ = transaction.save_locations(&locations, &branch_name).await;
         let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
         let expected_locations = vec![
-            RoswaalStoredLocation { location: locations[0].clone(), branch_name: Some(branch_name.clone()) },
-            RoswaalStoredLocation { location: locations[1].clone(), branch_name: Some(branch_name.clone()) }
+            RoswaalStoredLocation { location: locations[0].clone(), unmerged_branch_name: Some(branch_name.clone()) },
+            RoswaalStoredLocation { location: locations[1].clone(), unmerged_branch_name: Some(branch_name.clone()) }
         ];
         assert_eq!(saved_locations, expected_locations)
     }
@@ -116,7 +142,7 @@ mod tests {
         _ = transaction.save_locations(&locations, &branch_name).await;
         let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
         let expected_locations = vec![
-            RoswaalStoredLocation { location: locations[0].clone(), branch_name: Some(branch_name) }
+            RoswaalStoredLocation { location: locations[0].clone(), unmerged_branch_name: Some(branch_name) }
         ];
         assert_eq!(saved_locations, expected_locations);
     }
@@ -141,20 +167,61 @@ mod tests {
         let expected_locations = vec![
             RoswaalStoredLocation {
                 location: RoswaalLocation::new_without_validation("Antarctica", 32.29873932, 122.3939839),
-                branch_name: Some(branch_name.clone())
+                unmerged_branch_name: Some(branch_name.clone())
             },
             RoswaalStoredLocation {
                 location: RoswaalLocation::new_without_validation("Antarctica", 50.0, 50.0),
-                branch_name: Some(branch_name2.clone())
+                unmerged_branch_name: Some(branch_name2.clone())
             },
             RoswaalStoredLocation {
                 location: RoswaalLocation::new_without_validation("New York", 45.0, 45.0),
-                branch_name: Some(branch_name.clone())
+                unmerged_branch_name: Some(branch_name.clone())
             },
             RoswaalStoredLocation {
                 location: RoswaalLocation::new_without_validation("Oakland", 45.0, 45.0),
-                branch_name: Some(branch_name2.clone())
+                unmerged_branch_name: Some(branch_name2.clone())
             }
+        ];
+        assert_eq!(saved_locations, expected_locations)
+    }
+
+    #[tokio::test]
+    async fn save_and_merge_locations_removes_unmerged_branch_name() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test");
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
+        let locations = vec![
+            RoswaalLocation::new_without_validation("Antarctica", 32.29873932, 122.3939839),
+            RoswaalLocation::new_without_validation("New York", 45.0, 45.0)
+        ];
+        transaction.save_locations(&locations, &branch_name).await.unwrap();
+        transaction.merge_unmerged_locations(&branch_name).await.unwrap();
+        let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
+        let expected_locations = vec![
+            RoswaalStoredLocation { location: locations[0].clone(), unmerged_branch_name: None },
+            RoswaalStoredLocation { location: locations[1].clone(), unmerged_branch_name: None }
+        ];
+        assert_eq!(saved_locations, expected_locations)
+    }
+
+    #[tokio::test]
+    async fn save_and_merge_existing_location_overrides_previous_merged_location() {
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
+
+        let mut branch_name = RoswaalOwnedGitBranchName::new("test");
+        let mut locations = vec![RoswaalLocation::new_without_validation("New York", 45.0, 45.0)];
+        transaction.save_locations(&locations, &branch_name).await.unwrap();
+        transaction.merge_unmerged_locations(&branch_name).await.unwrap();
+
+        branch_name = RoswaalOwnedGitBranchName::new("test-2");
+        locations = vec![RoswaalLocation::new_without_validation("New York", 82.2987299, -6.90872987)];
+        transaction.save_locations(&locations, &branch_name).await.unwrap();
+        transaction.merge_unmerged_locations(&branch_name).await.unwrap();
+
+        let saved_locations = transaction.locations_in_alphabetical_order().await.unwrap();
+        let expected_locations = vec![
+            RoswaalStoredLocation { location: locations[0].clone(), unmerged_branch_name: None }
         ];
         assert_eq!(saved_locations, expected_locations)
     }

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -48,9 +48,9 @@ CREATE TABLE IF NOT EXISTS TestSteps (
     test_id INTEGER NOT NULL,
     content TEXT NOT_NULL,
     did_pass INT2 NOT NULL DEFAULT FALSE,
-    unmerged_branch_name TEXT,
     creation_date DATETIME NOT NULL DEFAULT (unixepoch()),
-    CONSTRAINT fk_test FOREIGN KEY(test_id) REFERENCES Tests(id)
+    UNIQUE(test_id, content),
+    CONSTRAINT fk_test FOREIGN KEY(test_id) REFERENCES Tests(id) ON DELETE CASCADE
 );
             "
         )


### PR DESCRIPTION
Implements merging unmerged locations and tests. This PR does not cover merging removed test changes, that will come soon.

When merging, we simply null out the `unmerged_branch_name` column in the database since the record is now "merged". If there exists a previously merged copy of the record, it is overwritten.

I also removed the `unmerged_branch_name` on the `TestSteps` table and instead used a cascade delete rule to delete it when the previously merged test is overwritten.