### PR TITLE
Cleanup + Fixes

### DIFF
--- a/src/git/metadata.rs
+++ b/src/git/metadata.rs
@@ -37,8 +37,13 @@ impl RoswaalGitRepositoryMetadata {
 
     /// Metadata for a local testing repo.
     pub fn for_testing() -> Self {
+        Self::for_testing_with_custom_base_branch(TEST_REPO_BASE_BRANCH_NAME)
+    }
+
+    /// Metadata for a local testing repo with a custom base branch name.
+    pub fn for_testing_with_custom_base_branch(base_branch_name: &str) -> Self {
         Self {
-            base_branch_name: "main".to_string(),
+            base_branch_name: base_branch_name.to_string(),
             repo_root_dir_path: "./FitnessProjectTest".to_string(),
             ssh_private_key_home_path: "./.ssh/id_mhayes".to_string(),
             test_cases_root_dir_path: "./FitnessProjectTest/roswaal".to_string(),
@@ -54,6 +59,8 @@ impl RoswaalGitRepositoryMetadata {
         }
     }
 }
+
+pub const TEST_REPO_BASE_BRANCH_NAME: &str = "main";
 
 impl RoswaalGitRepositoryMetadata {
     /// Returns the name of the branch that changes are primarily merged to (eg. development).

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -44,6 +44,9 @@ pub trait RoswaalGitRepositoryClient: Sized {
     /// Attempts to create this client from metadata.
     async fn try_new(metadata: &RoswaalGitRepositoryMetadata) -> Result<Self>;
 
+    /// Returns the metadata associated with this client.
+    fn metadata(&self) -> &RoswaalGitRepositoryMetadata;
+
     /// Performs the equivalent of a `git reset --hard HEAD`.
     async fn hard_reset_to_head(&self) -> Result<()>;
 
@@ -99,6 +102,10 @@ impl RoswaalGitRepositoryClient for LibGit2RepositoryClient {
         let repo = spawn_blocking(move || Repository::open(m1.relative_path("."))).await??;
         Self::thread(repo, metadata, rx);
         Ok(Self { sender: tx, metadata: metadata.clone() })
+    }
+
+    fn metadata(&self) -> &RoswaalGitRepositoryMetadata {
+        &self.metadata
     }
 
     async fn hard_reset_to_head(&self) -> Result<()> {

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -9,7 +9,7 @@ use tokio::process::Command;
 #[cfg(test)]
 use tokio::sync::Mutex;
 
-use super::{branch_name::RoswaalOwnedGitBranchName, metadata::RoswaalGitRepositoryMetadata, pull_request::{GithubPullRequest, GithubPullRequestOpen}, repo::{PullBranchStatus, RoswaalGitRepositoryClient, RoswaalGitRepository, LibGit2RepositoryClient}};
+use super::{branch_name::RoswaalOwnedGitBranchName, metadata::{self, RoswaalGitRepositoryMetadata}, pull_request::{GithubPullRequest, GithubPullRequestOpen}, repo::{LibGit2RepositoryClient, PullBranchStatus, RoswaalGitRepository, RoswaalGitRepositoryClient}};
 
 #[cfg(test)]
 pub struct TestGithubPullRequestOpen {
@@ -43,12 +43,18 @@ impl GithubPullRequestOpen for TestGithubPullRequestOpen {
 
 /// A `RoswaalGitRepositoryClient` implementation suitable for test-stubbing.
 #[cfg(test)]
-pub struct NoopGitRepositoryClient;
+pub struct NoopGitRepositoryClient {
+    metadata: RoswaalGitRepositoryMetadata
+}
 
 #[cfg(test)]
 impl RoswaalGitRepositoryClient for NoopGitRepositoryClient {
-    async fn try_new(_: &RoswaalGitRepositoryMetadata) -> Result<Self> {
-        Ok(Self)
+    async fn try_new(metadata: &RoswaalGitRepositoryMetadata) -> Result<Self> {
+        Ok(Self { metadata: metadata.clone() })
+    }
+
+    fn metadata(&self) -> &RoswaalGitRepositoryMetadata {
+        &self.metadata
     }
 
     async fn hard_reset_to_head(&self) -> Result<()> {

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS TestSteps (
     id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     test_id INTEGER NOT NULL,
     content TEXT NOT_NULL,
+    ordinal INTEGER NOT NULL,
     did_pass INT2 NOT NULL DEFAULT FALSE,
     creation_date DATETIME NOT NULL DEFAULT (unixepoch()),
     UNIQUE(test_id, content),


### PR DESCRIPTION
- Adds a `metadata` requirement to `RoswaalGitRepositoryClient` such that we don't have to pass a base branch into `EditGitRepositoryStatus::from_editing_new_branch`.
- Introduces an `ordinal` column in the `TestSteps` table to ensure tests are ordered correctly when querying a test.