### PR TITLE
Location Merge Operation

### DIFF
--- a/src/git/branch_name.rs
+++ b/src/git/branch_name.rs
@@ -1,12 +1,12 @@
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
-use sqlx::{sqlite::SqliteTypeInfo, Decode, Sqlite, Type};
+use sqlx::{sqlite::SqliteTypeInfo, Decode, Encode, Sqlite, Type};
 
 /// A type for a git branch name that is created by roswaal.
 ///
 /// Each branch name contains a 10 character nano id as its suffix in order to make each instance
 /// unique. This uniqueness ensures that duplicate branch names do not clash with each other.
-#[derive(Debug, PartialEq, Eq, Clone, Decode, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Encode, Serialize, Deserialize)]
 pub struct RoswaalOwnedGitBranchName(String);
 
 impl RoswaalOwnedGitBranchName {

--- a/src/git/branch_name.rs
+++ b/src/git/branch_name.rs
@@ -1,11 +1,12 @@
 use nanoid::nanoid;
+use serde::{Deserialize, Serialize};
 use sqlx::{sqlite::SqliteTypeInfo, Decode, Sqlite, Type};
 
 /// A type for a git branch name that is created by roswaal.
 ///
 /// Each branch name contains a 10 character nano id as its suffix in order to make each instance
 /// unique. This uniqueness ensures that duplicate branch names do not clash with each other.
-#[derive(Debug, PartialEq, Eq, Clone, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Decode, Serialize, Deserialize)]
 pub struct RoswaalOwnedGitBranchName(String);
 
 impl RoswaalOwnedGitBranchName {
@@ -100,7 +101,7 @@ mod tests {
             (RoswaalOwnedGitBranchName::new("i-am-groot"), None),
         ];
         for (name, kind) in names_to_kind {
-            assert_eq!(name.kind(), kind)
+            assert_eq!(name.kind(), kind);
         }
     }
 }

--- a/src/git/edit.rs
+++ b/src/git/edit.rs
@@ -70,7 +70,6 @@ mod tests {
             let file_path = metadata.relative_path("test-thing.txt");
             let status = EditGitRepositoryStatus::from_editing_new_branch(
                 &new_branch_name,
-                // metadata.base_branch_name(),
                 repo.transaction().await,
                 &pr_open,
                 async {
@@ -95,7 +94,6 @@ mod tests {
         let new_branch_name = RoswaalOwnedGitBranchName::new("test-edit");
         let status = EditGitRepositoryStatus::from_editing_new_branch(
             &new_branch_name,
-            // RoswaalGitRepositoryMetadata::for_testing().base_branch_name(),
             RoswaalGitRepository::noop().await.unwrap().transaction().await,
             &TestGithubPullRequestOpen::new(true),
             async {

--- a/src/git/pull_request.rs
+++ b/src/git/pull_request.rs
@@ -17,7 +17,7 @@ pub struct GithubPullRequest {
     owner: String,
     #[serde(skip)]
     repo: String,
-    head: String,
+    head: RoswaalOwnedGitBranchName,
     base: String
 }
 
@@ -41,7 +41,7 @@ Since I am Roswaaaaaaal, I do not need to specify any tiiiiiiiickets!
             owner: "tifapp".to_string(),
             repo: "FitnessProject".to_string(),
             base: "development".to_string(),
-            head: head_branch.to_string()
+            head: head_branch.clone()
         }
     }
 
@@ -103,6 +103,11 @@ impl GithubPullRequest {
     /// Returns the title of this PR.
     pub fn title(&self) -> &str {
         &self.title
+    }
+
+    /// Returns the head branch of this PR.
+    pub fn head_branch(&self) -> &RoswaalOwnedGitBranchName {
+        &self.head
     }
 
     /// Designates this PR specifically for testing and adjusts the title and body to disclaim

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -30,6 +30,10 @@ impl TestGithubPullRequestOpen {
         let pr = self.mutex.lock().await;
         pr.clone()
     }
+
+    pub async fn most_recent_head_branch_name(&self) -> Option<RoswaalOwnedGitBranchName> {
+        self.most_recent_pr().await.map(|pr| pr.head_branch().clone())
+    }
 }
 
 #[cfg(test)]

--- a/src/location/storage.rs
+++ b/src/location/storage.rs
@@ -40,7 +40,7 @@ impl <'a> RoswaalSqliteTransaction <'a> {
         let sqlite_location_names = query_as::<Sqlite, SqliteLocationName>(
             "SELECT name FROM Locations WHERE unmerged_branch_name = ?;"
         )
-        .bind(branch_name.to_string())
+        .bind(branch_name)
         .fetch_all(self.connection())
         .await?;
         let update_statements = sqlite_location_names.iter().map(|_| UPDATE_MERGE_UNMERGED_STATEMENT)
@@ -49,7 +49,7 @@ impl <'a> RoswaalSqliteTransaction <'a> {
         let mut update_query = query::<Sqlite>(&update_statements);
         for sqlite_name in sqlite_location_names.iter() {
             update_query = update_query.bind(sqlite_name.name.clone())
-                .bind(branch_name.to_string())
+                .bind(branch_name)
                 .bind(sqlite_name.name.clone());
         }
         update_query.execute(self.connection()).await?;
@@ -70,7 +70,7 @@ impl <'a> RoswaalSqliteTransaction <'a> {
             bulk_insert_query = bulk_insert_query.bind(location.coordinate().latitude())
                 .bind(location.coordinate().longitude())
                 .bind(&location.name().raw_value)
-                .bind(branch_name.to_string())
+                .bind(branch_name)
         }
         bulk_insert_query.execute(self.connection()).await?;
         Ok(())

--- a/src/operations/load_all_locations.rs
+++ b/src/operations/load_all_locations.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use crate::{location::storage::RoswaalStoredLocation, utils::sqlite::RoswaalSqlite, with_transaction};
+use crate::{location::storage::{LoadLocationsFilter, RoswaalStoredLocation}, utils::sqlite::RoswaalSqlite, with_transaction};
 
 #[derive(Debug, PartialEq)]
 pub enum LoadAllLocationsStatus {
@@ -11,13 +11,15 @@ impl LoadAllLocationsStatus {
     pub async fn from_stored_locations(sqlite: &RoswaalSqlite) -> Result<Self> {
         let mut transaction = sqlite.transaction().await?;
         with_transaction!(transaction, async {
-            transaction.locations_in_alphabetical_order().await.map(|locations| {
-                if locations.is_empty() {
-                    Self::NoLocations
-                } else {
-                    Self::Success(locations)
-                }
-            })
+            transaction.locations_in_alphabetical_order(LoadLocationsFilter::All)
+                .await
+                .map(|locations| {
+                    if locations.is_empty() {
+                        Self::NoLocations
+                    } else {
+                        Self::Success(locations)
+                    }
+                })
         })
     }
 }

--- a/src/operations/merge_branch.rs
+++ b/src/operations/merge_branch.rs
@@ -1,0 +1,32 @@
+use crate::{git::branch_name::{RoswaalOwnedBranchKind, RoswaalOwnedGitBranchName}, utils::sqlite::{self, RoswaalSqlite}};
+use anyhow::Result;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum MergeBranchStatus<'a> {
+    MergedNewLocations,
+    MergedTestRemovals,
+    MergedNewTests,
+    UnknownBranchKind(&'a RoswaalOwnedGitBranchName)
+}
+
+impl <'a> MergeBranchStatus<'a> {
+    pub async fn for_merging_branch_with_name(
+        branch_name: &'a RoswaalOwnedGitBranchName,
+        sqlite: &RoswaalSqlite
+    ) -> Result<Self> {
+        match branch_name.kind() {
+            Some(RoswaalOwnedBranchKind::AddLocations) => {
+                Ok(Self::MergedNewLocations)
+            },
+            Some(RoswaalOwnedBranchKind::AddTests) => {
+                Ok(Self::MergedNewTests)
+            },
+            Some(RoswaalOwnedBranchKind::RemoveTests) => {
+                Ok(Self::MergedTestRemovals)
+            },
+            None => {
+                Ok(Self::UnknownBranchKind(branch_name))
+            }
+        }
+    }
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,2 +1,3 @@
 pub mod add_locations;
 pub mod load_all_locations;
+pub mod merge_branch;

--- a/src/tests_data/storage.rs
+++ b/src/tests_data/storage.rs
@@ -26,7 +26,7 @@ impl <'a> RoswaalSqliteTransaction<'a> {
         let sqlite_location_names = query_as::<Sqlite, SqliteTestName>(
             "SELECT name FROM Tests WHERE unmerged_branch_name = ?;"
         )
-        .bind(branch_name.to_string())
+        .bind(branch_name)
         .fetch_all(self.connection())
         .await?;
         let update_statements = sqlite_location_names.iter().map(|_| UPDATE_MERGE_UNMERGED_STATEMENT)
@@ -35,7 +35,7 @@ impl <'a> RoswaalSqliteTransaction<'a> {
         let mut update_query = query::<Sqlite>(&update_statements);
         for sqlite_name in sqlite_location_names.iter() {
             update_query = update_query.bind(sqlite_name.name.clone())
-                .bind(branch_name.to_string())
+                .bind(branch_name)
                 .bind(sqlite_name.name.clone());
         }
         update_query.execute(self.connection()).await?;
@@ -59,7 +59,7 @@ impl <'a> RoswaalSqliteTransaction<'a> {
         for test in tests.iter() {
             tests_insert_query = tests_insert_query.bind(test.name())
                 .bind(test.description())
-                .bind(branch_name.to_string());
+                .bind(branch_name);
         }
         let id_rows = tests_insert_query.fetch_all(self.connection()).await?;
         let command_insert_statements = tests.iter()


### PR DESCRIPTION
Implements the top level operation for location merging, and adjusts the add locations operation to only generate code with existing merged locations. I made a few changes to existing types to do this.
1. `locations_in_alphabetical_order` now accepts a filter parameter. This filter can either load all, or only merged locations.
2. `RoswaalOwnedGitBranchName` now dervies Encode, Serialize, and Deserialize.
3. `GithubPullRequest` now exposes a field to get the head branch. This was needed since I need to inspect the opened branch for testing (in the same way that a human will inspect the branch name on github, and how the CI will pass that branch name to this tool).