### PR TITLE
Test creation operation

### DIFF
--- a/src/generation/test_case.rs
+++ b/src/generation/test_case.rs
@@ -1,3 +1,6 @@
+use tokio::{fs::{create_dir_all, File}, io::AsyncWriteExt};
+use anyhow::Result;
+
 use crate::{is_case, language::test::{RoswaalTest, RoswaalTestCommand}, utils::string::ToAsciiCamelCase};
 
 use super::{constants::GENERATED_HEADER, interface::RoswaalTypescriptGenerate};
@@ -6,6 +9,21 @@ use super::{constants::GENERATED_HEADER, interface::RoswaalTypescriptGenerate};
 pub struct TestCaseTypescript {
     test_case_code: String,
     test_action_code: String
+}
+
+impl TestCaseTypescript {
+    /// Saves this typescript code in files in the specified dirpath.
+    pub async fn save_in_dir(&self, dirpath: &str) -> Result<()> {
+        create_dir_all(dirpath).await?;
+        let mut file = File::create(format!("{}/TestCase.test.ts", dirpath)).await?;
+        file.write(self.test_case_code.as_bytes()).await?;
+        // file.flush().await?;
+
+        file = File::create(format!("{}/TestActions.ts", dirpath)).await?;
+        file.write(self.test_action_code.as_bytes()).await?;
+        // file.flush().await?;
+        Ok(())
+    }
 }
 
 impl RoswaalTypescriptGenerate<TestCaseTypescript> for RoswaalTestCommand {

--- a/src/git/metadata.rs
+++ b/src/git/metadata.rs
@@ -1,6 +1,6 @@
-use std::env;
+use std::{env, fmt::format};
 
-use crate::{language::ast::RoswaalTestSyntax, location::location::RoswaalStringLocations};
+use crate::{language::{ast::RoswaalTestSyntax, test::RoswaalTest}, location::location::RoswaalStringLocations};
 use super::{branch_name::RoswaalOwnedGitBranchName, pull_request::GithubPullRequest};
 
 /// A struct containing neccessary metadata for operating in a roswaal compatible git repo.
@@ -11,7 +11,7 @@ pub struct RoswaalGitRepositoryMetadata {
     ssh_private_key_home_path: String,
     test_cases_root_dir_path: String,
     add_test_cases_pr: fn(
-        test_names_with_syntax: &Vec<(&str, RoswaalTestSyntax)>,
+        test_names_with_syntax: &Vec<(&str, &RoswaalTestSyntax)>,
         &RoswaalOwnedGitBranchName
     ) -> GithubPullRequest,
     locations_path: String,
@@ -91,5 +91,17 @@ impl RoswaalGitRepositoryMetadata {
         branch_name: &RoswaalOwnedGitBranchName
     ) -> GithubPullRequest {
         (self.add_locations_pr)(locations, branch_name)
+    }
+
+    pub fn add_tests_pull_request<'a>(
+        &self,
+        tests: &Vec<(&str, &RoswaalTestSyntax<'a>)>,
+        branch_name: &RoswaalOwnedGitBranchName
+    ) -> GithubPullRequest {
+        (self.add_test_cases_pr)(tests, branch_name)
+    }
+
+    pub fn test_dirpath(&self, test: &RoswaalTest) -> String {
+        format!("{}/{}", self.test_cases_root_dir_path, test.dir_name())
     }
 }

--- a/src/git/pull_request.rs
+++ b/src/git/pull_request.rs
@@ -82,7 +82,7 @@ Since I am Roswaaaaaaal, I do not need to specify any tiiiiiiiickets!
 
     /// Creates a PR for test case creation on the frontend repo.
     pub fn for_test_cases_tif_react_frontend<'a, 'b>(
-        test_names_with_syntax: &Vec<(&'a str, RoswaalTestSyntax<'b>)>,
+        test_names_with_syntax: &Vec<(&'a str, &RoswaalTestSyntax<'b>)>,
         head_branch: &RoswaalOwnedGitBranchName
     ) -> Self {
         let joined_names = test_names_with_syntax.iter()
@@ -217,9 +217,11 @@ Requirement 3: Do more stuff";
         let test2 = "New Test: I am the next test
 Step 1: A
 Requirement 1: B";
+        let t1_syntax = RoswaalTestSyntax::from(test1);
+        let t2_syntax = RoswaalTestSyntax::from(test2);
         let tests_with_names = vec![
-            ("I am the test", RoswaalTestSyntax::from(test1)),
-            ("I am the next test", RoswaalTestSyntax::from(test2))
+            ("I am the test", &t1_syntax),
+            ("I am the next test", &t2_syntax)
         ];
         let pr = GithubPullRequest::for_test_cases_tif_react_frontend(
             &tests_with_names,

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -109,6 +109,14 @@ impl RoswaalGitRepository<NoopGitRepositoryClient> {
     pub async fn noop() -> Result<Self> {
         Self::open(&RoswaalGitRepositoryMetadata::for_testing()).await
     }
+
+    pub async fn noop_ensuring_merge_conflicts() -> Result<Self> {
+        let repo = Self::open(&RoswaalGitRepositoryMetadata::for_testing()).await?;
+        let mut transaction = repo.transaction().await;
+        transaction.ensure_merge_conflict();
+        drop(transaction);
+        Ok(repo)
+    }
 }
 
 #[cfg(test)]

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -8,7 +8,7 @@ use crate::location::name::{RoswaalLocationName, RoswaalLocationParsingResult};
 /// A token of roswaal test syntax.
 ///
 /// Each token represents a line of source code. See `RoswaalTestSyntax`.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RoswaalTestSyntaxCommand<'a> {
     /// A line denoting a "Step" command without its matching "Requirement"
     /// command.
@@ -88,7 +88,7 @@ impl <'a> RoswaalTestSyntaxCommand<'a> {
 /// Requirement 1: I am a requirement that matches step 1.
 /// Requirement 2: I am a requirement that is paired with step 2.
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RoswaalTestSyntax<'a> {
     source_code: &'a str
 }

--- a/src/language/ast.rs
+++ b/src/language/ast.rs
@@ -88,6 +88,7 @@ impl <'a> RoswaalTestSyntaxCommand<'a> {
 /// Requirement 1: I am a requirement that matches step 1.
 /// Requirement 2: I am a requirement that is paired with step 2.
 /// ```
+#[derive(Debug, PartialEq, Eq)]
 pub struct RoswaalTestSyntax<'a> {
     source_code: &'a str
 }
@@ -173,9 +174,82 @@ impl <'a> RoswaalTestSyntaxLineContent<'a> {
     }
 }
 
+static EXTRACT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    let regex = r"(?s)```\n(?<test>.*?)\n```";
+    RegexBuilder::new(regex)
+        .build()
+        .expect("Failed to compile extract tests syntax regex.")
+});
+
+/// Extracts a vector of `RoswaalTestSyntax` from a block of multiline text.
+///
+/// Each test should be placed between 2 "```\n" sequences in the string.
+pub fn extract_tests_syntax<'a>(text: &'a str) -> Vec<RoswaalTestSyntax<'a>> {
+    EXTRACT_REGEX.captures_iter(text).filter_map(|captures| {
+        captures.name("test").map(|m| RoswaalTestSyntax::from(m.as_str()))
+    })
+    .collect()
+}
+
 #[cfg(test)]
-mod ast_tests {
+mod tests {
     use super::*;
+
+    #[cfg(test)]
+    mod extract_tests {
+        use crate::language::ast::{extract_tests_syntax, RoswaalTestSyntax};
+
+        #[test]
+        fn test_no_syntax_from_empty_str() {
+            assert_eq!(extract_tests_syntax(""), vec![])
+        }
+
+        #[test]
+        fn test_no_syntax_from_single_line_back_ticks() {
+            assert_eq!(extract_tests_syntax("```New test: Invalid```"), vec![])
+        }
+
+        #[test]
+        fn test_no_syntax_from_single_multiline_invalid_back_ticks() {
+            assert_eq!(extract_tests_syntax("Hello ```New test: Invalid\n```"), vec![])
+        }
+
+        #[test]
+        fn test_syntax_from_markdown_str() {
+            let markdown = "
+```
+New test: Test
+Step 1: Get parsed
+Requirement 1: Cool
+```
+
+Hello world, I am some random comment between tests, not an actual test...
+
+```
+New Test: test 2
+Step 1: Nice
+Requirement 1: Awesome
+```
+
+More BS **here** at the bottom.
+";
+            assert_eq!(
+                extract_tests_syntax(markdown),
+                vec![
+                    RoswaalTestSyntax::from("\
+New test: Test
+Step 1: Get parsed
+Requirement 1: Cool"
+                    ),
+                    RoswaalTestSyntax::from("\
+New Test: test 2
+Step 1: Nice
+Requirement 1: Awesome"
+                    )
+                ]
+            )
+        }
+    }
 
     #[cfg(test)]
     mod token_tests {

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -4,7 +4,7 @@ use crate::location::name::{RoswaalLocationName, RoswaalLocationNameParsingError
 
 use super::{ast::{RoswaalTestSyntax, RoswaalTestSyntaxCommand, RoswaalTestSyntaxLineContent}, test::{RoswaalTest, RoswaalTestCommand}};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RoswaalCompilationError {
     line_number: u32,
     code: RoswaalCompilationErrorCode
@@ -16,7 +16,7 @@ impl RoswaalCompilationError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RoswaalCompilationErrorCode {
     NoTestName,
     NoTestSteps,
@@ -33,7 +33,7 @@ pub enum RoswaalCompilationErrorCode {
     TestNameAlreadyDeclared
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RoswaalCompilationDuplicateErrorCode {
     StepLabel,
     RequirementLabel

--- a/src/language/compiler.rs
+++ b/src/language/compiler.rs
@@ -10,6 +10,12 @@ pub struct RoswaalCompilationError {
     code: RoswaalCompilationErrorCode
 }
 
+impl RoswaalCompilationError {
+    pub fn new(line_number: u32, code: RoswaalCompilationErrorCode) -> Self {
+        Self { line_number, code }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum RoswaalCompilationErrorCode {
     NoTestName,
@@ -34,8 +40,8 @@ pub enum RoswaalCompilationDuplicateErrorCode {
 }
 
 /// A struct that holds compilation information on a roswaal test script.
-pub struct RoswaalCompileContext {
-    location_names: Vec<RoswaalLocationName>,
+pub struct RoswaalCompileContext<'a> {
+    location_names: Option<&'a Vec<RoswaalLocationName>>,
     errors: Vec<RoswaalCompilationError>,
     test_name: Option<String>,
     test_description: Option<String>,
@@ -44,16 +50,24 @@ pub struct RoswaalCompileContext {
     commands: Vec<CompiledCommand>
 }
 
-impl RoswaalCompileContext {
+impl <'a> RoswaalCompileContext<'a> {
     /// Creates a new empty context with no location or test names.
     pub fn empty() -> Self {
-        Self::new(vec![])
+        Self {
+            location_names: None,
+            errors: vec![],
+            test_name: None,
+            test_description: None,
+            matchable_steps: HashMap::new(),
+            matchable_requirements: HashMap::new(),
+            commands: vec![]
+        }
     }
 
     /// Creates a new context with the specified location names.
-    pub fn new(location_names: Vec<RoswaalLocationName>) -> Self {
+    pub fn new(location_names: &'a Vec<RoswaalLocationName>) -> Self {
         Self {
-            location_names,
+            location_names: Some(location_names),
             errors: vec![],
             test_name: None,
             test_description: None,
@@ -67,7 +81,7 @@ impl RoswaalCompileContext {
 /// A trait for self-initializing by compiling roswaal test syntax.
 pub trait RoswaalCompile: Sized {
     fn compile_syntax(
-        syntax: RoswaalTestSyntax,
+        syntax: &RoswaalTestSyntax,
         ctx: RoswaalCompileContext
     ) -> Result<Self, Vec<RoswaalCompilationError>>;
 
@@ -75,13 +89,13 @@ pub trait RoswaalCompile: Sized {
         source_code: &str,
         ctx: RoswaalCompileContext
     ) -> Result<Self, Vec<RoswaalCompilationError>> {
-        Self::compile_syntax(RoswaalTestSyntax::from(source_code), ctx)
+        Self::compile_syntax(&RoswaalTestSyntax::from(source_code), ctx)
     }
 }
 
 impl RoswaalCompile for RoswaalTest {
     fn compile_syntax(
-        syntax: RoswaalTestSyntax,
+        syntax: &RoswaalTestSyntax,
         mut ctx: RoswaalCompileContext
     ) -> Result<Self, Vec<RoswaalCompilationError>> {
         for line in syntax.lines() {
@@ -164,13 +178,13 @@ impl RoswaalCompile for RoswaalTest {
     }
 }
 
-impl RoswaalCompileContext {
+impl <'a> RoswaalCompileContext<'a> {
     fn append_location(&mut self, line_number: u32, location_name: RoswaalLocationName) {
-        if !self.location_names.iter().any(|name| name.matches(&location_name)) {
-            self.append_error(
-                line_number,
-                RoswaalCompilationErrorCode::UnknownLocationName(location_name.raw_name().to_string())
-            )
+        let error_code = RoswaalCompilationErrorCode::UnknownLocationName(
+            location_name.raw_name().to_string()
+        );
+        if !self.location_names.unwrap_or(&vec![]).iter().any(|name| name.matches(&location_name)) {
+            self.append_error(line_number, error_code)
         } else {
             let command = CompiledCommand {
                 line_number,
@@ -255,7 +269,7 @@ impl RoswaalCompileContext {
         self.matchable_requirements.insert(label_key, info);
     }
 
-    fn finalize<'a>(mut self) -> Result<RoswaalTest, Vec<RoswaalCompilationError>> {
+    fn finalize(mut self) -> Result<RoswaalTest, Vec<RoswaalCompilationError>> {
         let test_name = match self.test_name {
             Some(name) => name,
             _ => return Err(self.errors)
@@ -487,7 +501,7 @@ Set Location: world
 ";
         let result = RoswaalTest::compile(
             test,
-            RoswaalCompileContext::new(location_names)
+            RoswaalCompileContext::new(&location_names)
         );
         let error = RoswaalCompilationError {
             line_number: 2,
@@ -507,7 +521,7 @@ Requirement 1: sure, do the thing
 ";
         let result = RoswaalTest::compile(
             test,
-            RoswaalCompileContext::new(location_names)
+            RoswaalCompileContext::new(&location_names)
         );
         let error = RoswaalCompilationError {
             line_number: 3,
@@ -746,7 +760,7 @@ Requirement 1: Have the guy dying on the floor ask why he didn't block that
 ";
         let result = RoswaalTest::compile(
             test,
-            RoswaalCompileContext::new(vec!["new york".parse().unwrap()])
+            RoswaalCompileContext::new(&vec!["new york".parse().unwrap()])
         ).unwrap();
         let expected_test = RoswaalTest::new(
             "I'm Insane, From New York".to_string(),

--- a/src/language/test.rs
+++ b/src/language/test.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::location::name::RoswaalLocationName;
+use crate::{location::name::RoswaalLocationName, utils::string::ToAsciiKebabCase};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RoswaalTest {
@@ -22,6 +22,10 @@ impl RoswaalTest {
 impl RoswaalTest {
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn dir_name(&self) -> String {
+        self.name().to_ascii_kebab_case().to_ascii_lowercase()
     }
 
     pub fn commands(&self) -> &Vec<RoswaalTestCommand> {

--- a/src/operations/add_tests.rs
+++ b/src/operations/add_tests.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+
+pub enum AddTestsStatus {}
+
+impl AddTestsStatus {
+    pub async fn from_adding_tests() -> Result<Self> {
+        todo!()
+    }
+}

--- a/src/operations/add_tests.rs
+++ b/src/operations/add_tests.rs
@@ -1,9 +1,164 @@
 use anyhow::Result;
 
-pub enum AddTestsStatus {}
+use crate::{language::{ast::extract_tests_syntax, compiler::{RoswaalCompilationError, RoswaalCompile, RoswaalCompileContext}, test::RoswaalTest}, location::{name::RoswaalLocationName, storage::LoadLocationsFilter}, utils::sqlite::RoswaalSqlite, with_transaction};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AddTestsStatus {
+    Success(Vec<Result<RoswaalTest, Vec<RoswaalCompilationError>>>)
+}
 
 impl AddTestsStatus {
-    pub async fn from_adding_tests() -> Result<Self> {
-        todo!()
+    pub async fn from_adding_tests(
+        tests_str: &str,
+        sqlite: &RoswaalSqlite
+    ) -> Result<Self> {
+        let mut transaction = sqlite.transaction().await?;
+        with_transaction!(transaction, async {
+            let location_names = transaction.locations_in_alphabetical_order(
+                LoadLocationsFilter::MergedOnly
+            )
+            .await?
+            .iter()
+            .map(|l| l.location().name().clone())
+            .collect::<Vec<RoswaalLocationName>>();
+            let results = extract_tests_syntax(tests_str)
+                .iter()
+                .map(|syntax| {
+                    let compile_context = RoswaalCompileContext::new(&location_names);
+                    RoswaalTest::compile_syntax(syntax, compile_context)
+                })
+                .collect::<Vec<Result<RoswaalTest, Vec<RoswaalCompilationError>>>>();
+            Ok(Self::Success(results))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{git::{branch_name, metadata::RoswaalGitRepositoryMetadata, repo::RoswaalGitRepository, test_support::{with_clean_test_repo_access, TestGithubPullRequestOpen}}, language::{compiler::RoswaalCompilationErrorCode, test::RoswaalTestCommand}, operations::{add_locations::AddLocationsStatus, merge_branch::MergeBranchStatus}, utils::sqlite::RoswaalSqlite};
+
+    #[tokio::test]
+    async fn reports_results_of_compiling_multiple_tests() {
+        with_clean_test_repo_access(async {
+            let tests_str = "\
+```
+New Test: Basic Leave Event through Exploration as Attendee
+Abstract: Justin is looking for an event. Once he finds one, he realizes that her has other plans, and decides to leave.
+
+Step 1: Justin is signed in
+Step 2: Justin wants to find the nearest event
+Step 3: After finding an event, Justin wants to join it
+Step 4: After some pondering, Justin decides that he is not interested in the event and wants to leave
+Step 5: Justin has now left the event
+
+Requirement 1: Ensure Justin has signed into his account
+Requirement 2: Search for the nearest events, and go to the details for the nearest one
+Requirement 3: Have Justin join the event
+Requirement 4: Have Justin leave the event
+Requirement 5: Ensure that Justin has left the event successfully
+```
+```
+This is like an invalid test or something...
+```
+";
+            let status = AddTestsStatus::from_adding_tests(
+                tests_str,
+                &RoswaalSqlite::in_memory().await?
+            ).await?;
+            let expected_results = vec![
+                Ok(
+                    RoswaalTest::new(
+                        "Basic Leave Event through Exploration as Attendee".to_string(),
+                        Some("Justin is looking for an event. Once he finds one, he realizes that her has other plans, and decides to leave.".to_string()),
+                        vec![
+                            RoswaalTestCommand::Step {
+                                name: "Justin is signed in".to_string(),
+                                requirement: "Ensure Justin has signed into his account".to_string()
+                            },
+                            RoswaalTestCommand::Step {
+                                name: "Justin wants to find the nearest event".to_string(),
+                                requirement: "Search for the nearest events, and go to the details for the nearest one".to_string()
+                            },
+                            RoswaalTestCommand::Step {
+                                name: "After finding an event, Justin wants to join it".to_string(),
+                                requirement: "Have Justin join the event".to_string()
+                            },
+                            RoswaalTestCommand::Step {
+                                name: "After some pondering, Justin decides that he is not interested in the event and wants to leave".to_string(),
+                                requirement: "Have Justin leave the event".to_string()
+                            },
+                            RoswaalTestCommand::Step {
+                                name: "Justin has now left the event".to_string(),
+                                requirement: "Ensure that Justin has left the event successfully".to_string()
+                            }
+                        ]
+                    )
+                ),
+                Err(
+                    vec![
+                        RoswaalCompilationError::new(
+                            1,
+                            RoswaalCompilationErrorCode::InvalidCommandName(
+                                "This is like an invalid test or something...".to_string()
+                            )
+                        ),
+                        RoswaalCompilationError::new(1, RoswaalCompilationErrorCode::NoTestName)
+                    ]
+                )
+            ];
+            assert_eq!(status, AddTestsStatus::Success(expected_results));
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn only_uses_merged_location_names_when_compiling_tests() {
+        with_clean_test_repo_access(async {
+            let tests_str = "\
+```
+New Test: ABC
+
+Step 1: Do the thing
+Requirement 1: Do the thing
+Set Location: Test 2
+```
+```
+New Test: ABC 123
+
+Step 1: Do the thing
+Requirement 1: Do the thing
+Set Location: Test
+```
+";
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let repo = RoswaalGitRepository::noop().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            _ = AddLocationsStatus::from_adding_locations(
+                "Test, 5.0, 5.0",
+                &repo,
+                &sqlite,
+                &pr_open
+            ).await?;
+            _ = AddLocationsStatus::from_adding_locations(
+                "Test 2, 5.0, 5.0",
+                &repo,
+                &sqlite,
+                &pr_open
+            ).await?;
+            let branch_name = pr_open.most_recent_head_branch_name().await.unwrap();
+            _ = MergeBranchStatus::from_merging_branch_with_name(&branch_name, &sqlite).await?;
+            let status = AddTestsStatus::from_adding_tests(tests_str, &sqlite).await?;
+            match status {
+                AddTestsStatus::Success(results) => {
+                    assert!(results[0].is_ok());
+                    assert!(results[1].is_err());
+                },
+                _ => panic!()
+            }
+            Ok(())
+        })
+        .await.unwrap()
     }
 }

--- a/src/operations/add_tests.rs
+++ b/src/operations/add_tests.rs
@@ -1,19 +1,29 @@
-use anyhow::Result;
+use std::iter::zip;
 
-use crate::{language::{ast::extract_tests_syntax, compiler::{RoswaalCompilationError, RoswaalCompile, RoswaalCompileContext}, test::RoswaalTest}, location::{name::RoswaalLocationName, storage::LoadLocationsFilter}, utils::sqlite::RoswaalSqlite, with_transaction};
+use anyhow::Result;
+use tokio::spawn;
+
+use crate::{generation::interface::RoswaalTypescriptGenerate, git::{branch_name::{self, RoswaalOwnedGitBranchName}, edit::EditGitRepositoryStatus, metadata::{self, RoswaalGitRepositoryMetadata}, pull_request::GithubPullRequestOpen, repo::{RoswaalGitRepository, RoswaalGitRepositoryClient}}, language::{ast::{extract_tests_syntax, RoswaalTestSyntax}, compiler::{RoswaalCompilationError, RoswaalCompile, RoswaalCompileContext}, test::RoswaalTest}, location::{name::RoswaalLocationName, storage::LoadLocationsFilter}, utils::sqlite::RoswaalSqlite, with_transaction};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum AddTestsStatus {
-    Success(Vec<Result<RoswaalTest, Vec<RoswaalCompilationError>>>)
+    Success { results: Vec<Result<RoswaalTest, Vec<RoswaalCompilationError>>>, did_delete_branch: bool },
+    NoTestsFound,
+    MergeConflict,
+    FailedToOpenPullRequest
 }
 
 impl AddTestsStatus {
     pub async fn from_adding_tests(
         tests_str: &str,
-        sqlite: &RoswaalSqlite
+        sqlite: &RoswaalSqlite,
+        pr_open: &impl GithubPullRequestOpen,
+        git_repository: &RoswaalGitRepository<impl RoswaalGitRepositoryClient>
     ) -> Result<Self> {
+        let tests_syntax = extract_tests_syntax(tests_str);
+        if tests_syntax.is_empty() { return Ok(AddTestsStatus::NoTestsFound) }
         let mut transaction = sqlite.transaction().await?;
-        with_transaction!(transaction, async {
+        let (location_names, git_transaction) = with_transaction!(transaction, async {
             let location_names = transaction.locations_in_alphabetical_order(
                 LoadLocationsFilter::MergedOnly
             )
@@ -21,22 +31,72 @@ impl AddTestsStatus {
             .iter()
             .map(|l| l.location().name().clone())
             .collect::<Vec<RoswaalLocationName>>();
-            let results = extract_tests_syntax(tests_str)
-                .iter()
-                .map(|syntax| {
-                    let compile_context = RoswaalCompileContext::new(&location_names);
-                    RoswaalTest::compile_syntax(syntax, compile_context)
-                })
-                .collect::<Vec<Result<RoswaalTest, Vec<RoswaalCompilationError>>>>();
-            Ok(Self::Success(results))
-        })
+            Ok((location_names, git_repository.transaction().await))
+        })?;
+        let branch_name = RoswaalOwnedGitBranchName::for_adding_tests();
+        let metadata = git_transaction.metadata().clone();
+        let cloned_tests_syntax = tests_syntax.clone();
+        let results = cloned_tests_syntax
+            .iter()
+            .map(|syntax| {
+                let compile_context = RoswaalCompileContext::new(&location_names);
+                RoswaalTest::compile_syntax(syntax, compile_context)
+            })
+            .collect::<Vec<Result<RoswaalTest, Vec<RoswaalCompilationError>>>>();
+        if results.iter().filter(|r| r.is_ok()).count() == 0 {
+            return Ok(Self::Success { results, did_delete_branch: false })
+        }
+        let edit_status = EditGitRepositoryStatus::from_editing_new_branch(
+            &branch_name,
+            git_transaction,
+            pr_open,
+            async {
+                let futures = results.iter().filter_map(|r| {
+                    if let Ok(test) = r {
+                        let test = test.clone();
+                        let metadata = metadata.clone();
+                        Some(
+                            spawn(async move {
+                                test.typescript().save_in_dir(&metadata.test_dirpath(&test)).await
+                            })
+                        )
+                    } else {
+                        None
+                    }
+                });
+                for future in futures {
+                    future.await??;
+                }
+                let test_names_with_syntax = zip(results.iter(), tests_syntax.iter())
+                    .filter_map(|(r, syntax)| {
+                        if let Ok(test) = r {
+                            Some((test.name(), syntax))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<(&str, &RoswaalTestSyntax<'_>)>>();
+                Ok(metadata.add_tests_pull_request(&test_names_with_syntax, &branch_name))
+            }
+        ).await?;
+        match edit_status {
+            EditGitRepositoryStatus::Success { did_delete_branch } => {
+                Ok(Self::Success { results, did_delete_branch })
+            },
+            EditGitRepositoryStatus::FailedToOpenPullRequest => {
+                Ok(Self::FailedToOpenPullRequest)
+            },
+            EditGitRepositoryStatus::MergeConflict => {
+                Ok(Self::MergeConflict)
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{git::{branch_name, metadata::RoswaalGitRepositoryMetadata, repo::RoswaalGitRepository, test_support::{with_clean_test_repo_access, TestGithubPullRequestOpen}}, language::{compiler::RoswaalCompilationErrorCode, test::RoswaalTestCommand}, operations::{add_locations::AddLocationsStatus, merge_branch::MergeBranchStatus}, utils::sqlite::RoswaalSqlite};
+    use crate::{git::{branch_name, metadata::RoswaalGitRepositoryMetadata, repo::RoswaalGitRepository, test_support::{read_string, with_clean_test_repo_access, TestGithubPullRequestOpen}}, language::{compiler::RoswaalCompilationErrorCode, test::RoswaalTestCommand}, operations::{add_locations::AddLocationsStatus, merge_branch::MergeBranchStatus}, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn reports_results_of_compiling_multiple_tests() {
@@ -64,7 +124,9 @@ This is like an invalid test or something...
 ";
             let status = AddTestsStatus::from_adding_tests(
                 tests_str,
-                &RoswaalSqlite::in_memory().await?
+                &RoswaalSqlite::in_memory().await?,
+                &TestGithubPullRequestOpen::new(false),
+                 &RoswaalGitRepository::noop().await?
             ).await?;
             let expected_results = vec![
                 Ok(
@@ -107,7 +169,7 @@ This is like an invalid test or something...
                     ]
                 )
             ];
-            assert_eq!(status, AddTestsStatus::Success(expected_results));
+            assert_eq!(status, AddTestsStatus::Success { results: expected_results, did_delete_branch: true });
             Ok(())
         })
         .await.unwrap();
@@ -149,9 +211,14 @@ Set Location: Test
             ).await?;
             let branch_name = pr_open.most_recent_head_branch_name().await.unwrap();
             _ = MergeBranchStatus::from_merging_branch_with_name(&branch_name, &sqlite).await?;
-            let status = AddTestsStatus::from_adding_tests(tests_str, &sqlite).await?;
+            let status = AddTestsStatus::from_adding_tests(
+                tests_str,
+                &sqlite,
+                &TestGithubPullRequestOpen::new(false),
+                 &RoswaalGitRepository::noop().await?
+            ).await?;
             match status {
-                AddTestsStatus::Success(results) => {
+                AddTestsStatus::Success { results, did_delete_branch: _ } => {
                     assert!(results[0].is_ok());
                     assert!(results[1].is_err());
                 },
@@ -160,5 +227,179 @@ Set Location: Test
             Ok(())
         })
         .await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn generates_test_case_and_test_action_code() {
+        with_clean_test_repo_access(async {
+            let tests_str = "\
+```
+New Test: ABC 123
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            let metadata = RoswaalGitRepositoryMetadata::for_testing();
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            _ = AddTestsStatus::from_adding_tests(
+                tests_str,
+                &sqlite,
+                &TestGithubPullRequestOpen::new(false),
+                 &RoswaalGitRepository::noop().await?
+            ).await?;
+            let test_case_code = read_string(
+                &metadata.relative_path("roswaal/abc-123/TestCase.test.ts")
+            ).await?;
+            let test_action_code = read_string(
+                &metadata.relative_path("roswaal/abc-123/TestActions.ts")
+            ).await?;
+            let expected_test_case_code = "\
+// Generated by Roswaal, do not touch.
+
+import * as TestActions from \"./TestActions\"
+import { launchApp } from \"../Launch\"
+import { RoswaalTestCase } from \"../TestCase\"
+import { roswaalClient } from \"../Client\"
+
+test(\"ABC 123\", async () => {
+  const testCase = new RoswaalTestCase(\"ABC 123\", TestActions.beforeLaunch)
+  // Do the thing
+  testCase.appendAction(TestActions.doTheThing)
+  await roswaalClient.run(testCase)
+})
+";
+            let expected_test_actions_code = "\
+import { TestAppLaunchConfig } from \"../Launch\"
+
+export const beforeLaunch = async (): Promise<TestAppLaunchConfig> => {
+  // Perform any setup work in here, (setting location, reseting device
+  // permissions, etc.)
+  return {}
+}
+
+export const doTheThing = async () => {
+  // Do the thing
+  throw new Error(\"TODO\")
+}
+";
+            assert_eq!(test_case_code, expected_test_case_code);
+            assert_eq!(test_action_code, expected_test_actions_code);
+            Ok(())
+        })
+        .await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn opens_pr_for_adding_new_tests() {
+        with_clean_test_repo_access(async {
+            let tests_str = "\
+```
+New Test: ABC 123
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+```
+New Test: I am the strong
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            _ = AddTestsStatus::from_adding_tests(
+                tests_str,
+                &sqlite,
+                &pr_open,
+                 &RoswaalGitRepository::noop().await?
+            ).await?;
+            let pr = pr_open.most_recent_pr().await.unwrap();
+            assert!(pr.title().contains("Add Tests \"ABC 123\", \"I am the strong\""));
+            Ok(())
+        })
+        .await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn reports_pr_open_failed_status_when_failing_to_open_pr() {
+        with_clean_test_repo_access(async {
+            let tests_str = "\
+```
+New Test: ABC 123
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(true);
+            let status = AddTestsStatus::from_adding_tests(
+                tests_str,
+                &sqlite,
+                &pr_open,
+                &RoswaalGitRepository::noop().await?
+            ).await?;
+            assert_eq!(status, AddTestsStatus::FailedToOpenPullRequest);
+            Ok(())
+        })
+        .await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn reports_merge_conflict_status_when_merge_conflict_occurs() {
+        with_clean_test_repo_access(async {
+            let tests_str = "\
+```
+New Test: ABC 123
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(true);
+            let status = AddTestsStatus::from_adding_tests(
+                tests_str,
+                &sqlite,
+                &pr_open,
+                &RoswaalGitRepository::noop_ensuring_merge_conflicts().await?
+            ).await?;
+            assert_eq!(status, AddTestsStatus::MergeConflict);
+            Ok(())
+        })
+        .await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn reports_no_tests_found_status_when_empty_tests_string() {
+        let tests_str = "";
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let pr_open = TestGithubPullRequestOpen::new(true);
+        let status = AddTestsStatus::from_adding_tests(
+            tests_str,
+            &sqlite,
+            &pr_open,
+            &RoswaalGitRepository::noop_ensuring_merge_conflicts().await.unwrap()
+        ).await.unwrap();
+        assert_eq!(status, AddTestsStatus::NoTestsFound);
+    }
+
+    #[tokio::test]
+    async fn does_not_open_pr_when_no_compiling_tests() {
+        let tests_str = "\
+```
+dlkjldjlkdjlkjdlkdj
+```
+```
+lkjdlkjlkjalkjslkdjdflkj
+```
+";
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let pr_open = TestGithubPullRequestOpen::new(true);
+        _ = AddTestsStatus::from_adding_tests(
+            tests_str,
+            &sqlite,
+            &pr_open,
+            &RoswaalGitRepository::noop().await.unwrap()
+        ).await.unwrap();
+        let pr = pr_open.most_recent_pr().await;
+        assert_eq!(pr, None)
     }
 }

--- a/src/operations/load_tests.rs
+++ b/src/operations/load_tests.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+
+use crate::{tests_data::storage::RoswaalStoredTest, utils::sqlite::RoswaalSqlite, with_transaction};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum LoadTestsStatus {
+    Success(Vec<RoswaalStoredTest>),
+    NoTests
+}
+
+impl LoadTestsStatus {
+    pub async fn for_loading_tests(sqlite: &RoswaalSqlite) -> Result<Self> {
+        let mut transaction = sqlite.transaction().await?;
+        with_transaction!(transaction, async {
+            let tests = transaction.tests_in_alphabetical_order().await?;
+            if tests.is_empty() {
+                Ok(Self::NoTests)
+            } else {
+                Ok(Self::Success(tests))
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{git::{repo::RoswaalGitRepository, test_support::{with_clean_test_repo_access, TestGithubPullRequestOpen}}, operations::add_tests::AddTestsStatus, utils::sqlite::RoswaalSqlite};
+
+    #[tokio::test]
+    async fn reports_no_tests_when_no_tests_saved() {
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let status = LoadTestsStatus::for_loading_tests(&sqlite).await.unwrap();
+        assert_eq!(status, LoadTestsStatus::NoTests)
+    }
+
+    #[tokio::test]
+    async fn reports_success_with_saved_tests() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let tests_str = "\
+```
+New Test: ABC
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+```
+New Test: ABC 123
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            _ = AddTestsStatus::from_adding_tests(
+                tests_str,
+                &sqlite,
+                &TestGithubPullRequestOpen::new(false),
+                &RoswaalGitRepository::noop().await?
+            ).await?;
+            let status = LoadTestsStatus::for_loading_tests(&sqlite).await?;
+            match status {
+                LoadTestsStatus::Success(tests) => {
+                    assert_eq!(tests[0].name(), "ABC");
+                    assert_eq!(tests[1].name(), "ABC 123")
+                },
+                _ => panic!()
+            }
+            Ok(())
+        })
+        .await.unwrap();
+    }
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -2,3 +2,4 @@ pub mod add_locations;
 pub mod load_all_locations;
 pub mod merge_branch;
 pub mod add_tests;
+pub mod load_tests;

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,3 +1,4 @@
 pub mod add_locations;
 pub mod load_all_locations;
 pub mod merge_branch;
+pub mod add_tests;

--- a/src/tests_data/storage.rs
+++ b/src/tests_data/storage.rs
@@ -15,6 +15,12 @@ pub struct RoswaalStoredTest {
     unmerged_branch_name: Option<RoswaalOwnedGitBranchName>
 }
 
+impl RoswaalStoredTest {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct RoswaalStoredTestCommand {
     command: RoswaalTestCommand,
@@ -22,7 +28,7 @@ pub struct RoswaalStoredTestCommand {
 }
 
 impl <'a> RoswaalSqliteTransaction<'a> {
-    async fn merge_unmerged_tests(&mut self, branch_name: &RoswaalOwnedGitBranchName) -> Result<()> {
+    pub async fn merge_unmerged_tests(&mut self, branch_name: &RoswaalOwnedGitBranchName) -> Result<()> {
         let sqlite_location_names = query_as::<Sqlite, SqliteTestName>(
             "SELECT name FROM Tests WHERE unmerged_branch_name = ?;"
         )
@@ -42,7 +48,7 @@ impl <'a> RoswaalSqliteTransaction<'a> {
         Ok(())
     }
 
-    async fn save_tests(
+    pub async fn save_tests(
         &mut self,
         tests: &Vec<RoswaalTest>,
         branch_name: &RoswaalOwnedGitBranchName
@@ -81,7 +87,7 @@ impl <'a> RoswaalSqliteTransaction<'a> {
         Ok(())
     }
 
-    async fn tests_in_alphabetical_order(&mut self) -> Result<Vec<RoswaalStoredTest>> {
+    pub async fn tests_in_alphabetical_order(&mut self) -> Result<Vec<RoswaalStoredTest>> {
         let sqlite_tests = query_as::<Sqlite, SqliteStoredTestRow>(SELECT_TESTS_IN_ALPHABETICAL_ORDER)
             .fetch_all(self.connection())
             .await?;

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -33,6 +33,15 @@ pub trait UppercaseFirstAsciiCharacter: ToString {
 impl UppercaseFirstAsciiCharacter for String {}
 impl UppercaseFirstAsciiCharacter for &str {}
 
+pub trait ToAsciiKebabCase: ToString {
+    fn to_ascii_kebab_case(&self) -> String {
+        self.to_string().trim().replace(" ", "-")
+    }
+}
+
+impl ToAsciiKebabCase for String {}
+impl ToAsciiKebabCase for &str {}
+
 #[cfg(test)]
 mod string_utils_tests {
     use super::*;
@@ -76,5 +85,23 @@ mod string_utils_tests {
     #[test]
     fn test_pascal_case_uppercases_first_letter_of_all_words_and_trims_white_space() {
         assert_eq!("santa cruz".to_ascii_pascal_case(), String::from("SantaCruz"))
+    }
+
+    #[test]
+    fn to_ascii_kebab_case() {
+        let strings = vec![
+            ("hello world", "hello-world"),
+            ("Hello world", "Hello-world"),
+            ("", ""),
+            ("test", "test"),
+            ("it's really cold outside", "it's-really-cold-outside"),
+            ("hello + world", "hello-+-world"),
+            ("hello@world", "hello@world"),
+            ("   hello world   ", "hello-world"),
+            ("hello    world", "hello----world")
+        ];
+        for (before, after) in strings {
+            assert_eq!(before.to_ascii_kebab_case(), after.to_string())
+        }
     }
 }


### PR DESCRIPTION
Implements the operation for compiling and generating the code in test cases. I had to make a few small changes to the reference behavior of the compiler, and I also added a few new data types to keep the operation as clean as possible. Notably, there was a lot of pure logic around dealing the with the compilation results, so I made a `RoswaalTestCompilationResults` type to help with that.

## Parsing Tests

The user will pass a list of tests as a string with each test inside "```" blocks. Here's an example:

> Hello world this is not a test
> ```
> New Test: But everything in here is!
> Step 1: I am groot
> ...
> ```
> Not a test again.
> ```
> New Test: In a test again.
> ...
> ``` 

## General Flow

The general flow of the operation is as follows:
1. Extract the tests from the input string.
2. Load the existing location names to feed them to `RoswaalCompileContext`, and begin the git transaction.
3. Compile the tests.
4. Generate the typescript from all tests that compiled successfully.
  - If no tests are compiled successfully, we bail out here.
5. Open the PR.
6. Save the compiled tests in an unmerged state.

## Fixing Code Generation

Among other things, I also fixed a bug in the code generation. Test names with special characters would cause an invalid function name to be generated. Therefore, I removed all characters from the function name when generating the output.