### PR TITLE
Remove Tests

### DIFF
--- a/src/git/metadata.rs
+++ b/src/git/metadata.rs
@@ -1,6 +1,6 @@
 use std::{env, fmt::format};
 
-use crate::{language::{ast::RoswaalTestSyntax, test::RoswaalTest}, location::location::RoswaalStringLocations, utils::string::ToAsciiKebabCase};
+use crate::{language::{ast::RoswaalTestSyntax, test::RoswaalTest}, location::location::RoswaalStringLocations, tests_data::query::RoswaalTestNamesString, utils::string::ToAsciiKebabCase};
 use super::{branch_name::RoswaalOwnedGitBranchName, pull_request::GithubPullRequest};
 
 /// A struct containing neccessary metadata for operating in a roswaal compatible git repo.
@@ -18,6 +18,10 @@ pub struct RoswaalGitRepositoryMetadata {
     add_locations_pr: fn(
         &RoswaalStringLocations,
         &RoswaalOwnedGitBranchName
+    ) -> GithubPullRequest,
+    remove_tests_pr: fn(
+        &RoswaalTestNamesString,
+        &RoswaalOwnedGitBranchName
     ) -> GithubPullRequest
 }
 
@@ -31,7 +35,8 @@ impl RoswaalGitRepositoryMetadata {
             test_cases_root_dir_path: "./FitnessProject/roswaal".to_string(),
             add_test_cases_pr: GithubPullRequest::for_test_cases_tif_react_frontend,
             locations_path: "./FitnessProject/roswaal/Locations.ts".to_string(),
-            add_locations_pr: GithubPullRequest::for_locations_tif_react_frontend
+            add_locations_pr: GithubPullRequest::for_locations_tif_react_frontend,
+            remove_tests_pr: GithubPullRequest::for_removing_test_cases_tif_react_frontend
         }
     }
 
@@ -55,6 +60,13 @@ impl RoswaalGitRepositoryMetadata {
             add_locations_pr: |locations, head_branch| {
                 GithubPullRequest::for_locations_tif_react_frontend(locations, head_branch)
                     .for_testing_do_not_merge()
+            },
+            remove_tests_pr: |test_names, head_branch| {
+                GithubPullRequest::for_removing_test_cases_tif_react_frontend(
+                    test_names,
+                    head_branch
+                )
+                .for_testing_do_not_merge()
             }
         }
     }
@@ -99,6 +111,14 @@ impl RoswaalGitRepositoryMetadata {
         branch_name: &RoswaalOwnedGitBranchName
     ) -> GithubPullRequest {
         (self.add_test_cases_pr)(tests, branch_name)
+    }
+
+    pub fn remove_tests_pull_request<'a>(
+        &self,
+        test_names: &RoswaalTestNamesString,
+        branch_name: &RoswaalOwnedGitBranchName
+    ) -> GithubPullRequest {
+        (self.remove_tests_pr)(test_names, branch_name)
     }
 
     pub fn test_dirpath(&self, test_name: &str) -> String {

--- a/src/git/metadata.rs
+++ b/src/git/metadata.rs
@@ -1,6 +1,6 @@
 use std::{env, fmt::format};
 
-use crate::{language::{ast::RoswaalTestSyntax, test::RoswaalTest}, location::location::RoswaalStringLocations};
+use crate::{language::{ast::RoswaalTestSyntax, test::RoswaalTest}, location::location::RoswaalStringLocations, utils::string::ToAsciiKebabCase};
 use super::{branch_name::RoswaalOwnedGitBranchName, pull_request::GithubPullRequest};
 
 /// A struct containing neccessary metadata for operating in a roswaal compatible git repo.
@@ -101,7 +101,8 @@ impl RoswaalGitRepositoryMetadata {
         (self.add_test_cases_pr)(tests, branch_name)
     }
 
-    pub fn test_dirpath(&self, test: &RoswaalTest) -> String {
-        format!("{}/{}", self.test_cases_root_dir_path, test.dir_name())
+    pub fn test_dirpath(&self, test_name: &str) -> String {
+        let name = test_name.to_ascii_kebab_case().to_ascii_lowercase();
+        format!("{}/{}", self.test_cases_root_dir_path, name)
     }
 }

--- a/src/language/test.rs
+++ b/src/language/test.rs
@@ -24,10 +24,6 @@ impl RoswaalTest {
         &self.name
     }
 
-    pub fn dir_name(&self) -> String {
-        self.name().to_ascii_kebab_case().to_ascii_lowercase()
-    }
-
     pub fn commands(&self) -> &Vec<RoswaalTestCommand> {
         &self.commands
     }

--- a/src/operations/add_locations.rs
+++ b/src/operations/add_locations.rs
@@ -42,12 +42,12 @@ impl AddLocationsStatus {
                     &stored_locations,
                     metadata.locations_path()
                 ).await?;
-                Ok(metadata.add_locations_pull_request(&string_locations, &branch_name))
+                Ok((metadata.add_locations_pull_request(&string_locations, &branch_name), ()))
             }
         ).await?;
 
         match edit_status {
-            EditGitRepositoryStatus::Success { did_delete_branch } => {
+            EditGitRepositoryStatus::Success { did_delete_branch, value: _ } => {
                 transaction = sqlite.transaction().await?;
                 with_transaction!(transaction, async {
                     transaction.save_locations(&string_locations.locations(), &branch_name).await?;

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -3,3 +3,4 @@ pub mod load_all_locations;
 pub mod merge_branch;
 pub mod add_tests;
 pub mod search_tests;
+pub mod remove_tests;

--- a/src/operations/remove_tests.rs
+++ b/src/operations/remove_tests.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+
+pub enum RemoveTestsStatus {
+
+}
+
+impl RemoveTestsStatus {
+    pub async fn from_removing_tests() -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/operations/remove_tests.rs
+++ b/src/operations/remove_tests.rs
@@ -1,11 +1,244 @@
+use std::{error::Error, fmt::Display, future};
+
 use anyhow::Result;
+use tokio::{fs::remove_dir_all, spawn};
 
+use crate::{git::{branch_name::{self, RoswaalOwnedBranchKind, RoswaalOwnedGitBranchName}, edit::EditGitRepositoryStatus, metadata::{self, RoswaalGitRepositoryMetadata}, pull_request::{GithubPullRequest, GithubPullRequestOpen}, repo::{RoswaalGitRepository, RoswaalGitRepositoryClient}}, tests_data::query::RoswaalTestNamesString, utils::sqlite::RoswaalSqlite};
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum RemoveTestsStatus {
-
+    Success { removed_test_names: Vec<String>, should_warn_undeleted_branch: bool },
+    NoTestsRemoved,
+    FailedToOpenPullRequest,
+    MergeConflict
 }
 
 impl RemoveTestsStatus {
-    pub async fn from_removing_tests() -> Result<()> {
+    pub async fn from_removing_tests(
+        query_str: &str,
+        sqlite: &RoswaalSqlite,
+        git_repository: &RoswaalGitRepository<impl RoswaalGitRepositoryClient>,
+        pr_open: &impl GithubPullRequestOpen
+    ) -> Result<Self> {
+        let test_names = RoswaalTestNamesString(query_str);
+        if test_names.is_empty() { return Ok(Self::NoTestsRemoved) }
+
+        let transaction = git_repository.transaction().await;
+        let branch_name = RoswaalOwnedGitBranchName::for_removing_tests();
+        let metadata = transaction.metadata().clone();
+        let edit_result = EditGitRepositoryStatus::from_editing_new_branch(
+            &branch_name,
+            transaction,
+            pr_open,
+            async {
+                let removed_test_names = Self::remove_test_names(&test_names, &metadata).await?;
+                let pr = GithubPullRequest::for_removing_test_cases_tif_react_frontend(
+                    &test_names,
+                    &branch_name
+                );
+                Ok((pr, removed_test_names))
+            }
+        ).await;
+
+        match edit_result {
+            Ok(EditGitRepositoryStatus::Success { did_delete_branch, value: removed_test_names }) => {
+                Ok(Self::Success { removed_test_names, should_warn_undeleted_branch: !did_delete_branch })
+            },
+            Ok(EditGitRepositoryStatus::MergeConflict) => {
+                Ok(Self::MergeConflict)
+            },
+            Ok(EditGitRepositoryStatus::FailedToOpenPullRequest) => {
+                Ok(Self::FailedToOpenPullRequest)
+            },
+            Err(err) => {
+                let _: NoTestsToRemoveError = err.downcast()?;
+                Ok(Self::Success { removed_test_names: vec![], should_warn_undeleted_branch: true })
+            }
+        }
+    }
+
+    async fn remove_test_names(
+        test_names: &RoswaalTestNamesString<'_>,
+        metadata: &RoswaalGitRepositoryMetadata
+    ) -> Result<Vec<String>> {
+        let futures = test_names.iter().map(|n| {
+            let name = n.to_string();
+            let dir_path = metadata.test_dirpath(n);
+            spawn(async {
+                remove_dir_all(dir_path).await?;
+                Ok::<String, anyhow::Error>(name)
+            })
+        });
+        let mut removed_test_names = Vec::<String>::new();
+        for future in futures {
+            if let Ok(name) = future.await? {
+                removed_test_names.push(name)
+            }
+        }
+        if removed_test_names.is_empty() {
+            Err(anyhow::Error::new(NoTestsToRemoveError))
+        } else {
+            Ok(removed_test_names)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NoTestsToRemoveError;
+
+impl Display for NoTestsToRemoveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NoTestsToRemoveError")
+    }
+}
+
+impl Error for NoTestsToRemoveError {}
+
+#[cfg(test)]
+mod tests {
+    use tokio::fs::try_exists;
+
+    use super::*;
+    use crate::{git::{metadata::RoswaalGitRepositoryMetadata, test_support::{with_clean_test_repo_access, NoopGitRepositoryClient, TestGithubPullRequestOpen}}, operations::{add_tests::AddTestsStatus, merge_branch::MergeBranchStatus}, utils::sqlite::RoswaalSqlite};
+
+    #[tokio::test]
+    async fn reports_no_test_removed_when_empty_query_string() {
+        let status = RemoveTestsStatus::from_removing_tests(
+            "",
+            &RoswaalSqlite::in_memory().await.unwrap(),
+            &RoswaalGitRepository::noop().await.unwrap(),
+            &TestGithubPullRequestOpen::new(false)
+        ).await.unwrap();
+        assert_eq!(status, RemoveTestsStatus::NoTestsRemoved)
+    }
+
+    #[tokio::test]
+    async fn removes_code_generated_by_adding_test() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let metadata = RoswaalGitRepositoryMetadata::for_testing();
+            let repo = RoswaalGitRepository::noop().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            add_and_merge_blob(&sqlite, &repo, &pr_open).await?;
+            remove_blob(&sqlite, &repo, &pr_open).await?;
+            assert!(!try_exists(metadata.relative_path("roswaal/blob")).await?);
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pr_not_opened_when_no_test_names_exist() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let repo = RoswaalGitRepository::noop().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            _ = remove_blob(&sqlite, &repo, &pr_open).await?;
+            assert!(pr_open.most_recent_pr().await.is_none());
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pr_opened_when_test_cases_removed() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let repo = RoswaalGitRepository::noop().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            add_and_merge_blob(&sqlite, &repo, &pr_open).await?;
+            _ = remove_blob(&sqlite, &repo, &pr_open).await?;
+            assert!(pr_open.most_recent_pr().await.unwrap().title().contains("Remove Tests Blob"));
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_tests_names_that_were_removed_in_success_status() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let repo = RoswaalGitRepository::noop().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            add_and_merge_blob(&sqlite, &repo, &pr_open).await?;
+            let test_names_str = "\
+Blob
+Zanza The Divine
+";
+            let status = RemoveTestsStatus::from_removing_tests(
+                test_names_str,
+                &sqlite,
+                &repo,
+                &pr_open
+            ).await?;
+            let expected_status = RemoveTestsStatus::Success {
+                removed_test_names: vec!["Blob".to_string()],
+                should_warn_undeleted_branch: false
+            };
+            assert_eq!(status, expected_status);
+            assert!(pr_open.most_recent_pr().await.unwrap().title().contains("Remove Tests Blob"));
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_pr_open_failed_status_when_failing_to_open_pr() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(true);
+            let repo = RoswaalGitRepository::noop().await?;
+            add_and_merge_blob(&sqlite, &repo, &pr_open).await?;
+            let status = remove_blob(&sqlite, &repo, &pr_open).await?;
+            assert_eq!(status, RemoveTestsStatus::FailedToOpenPullRequest);
+            Ok(())
+        })
+        .await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn reports_merge_conflict_status_when_merge_conflict_occurs() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            let repo = RoswaalGitRepository::noop_ensuring_merge_conflicts().await?;
+            let status = remove_blob(&sqlite, &repo, &pr_open).await?;
+            assert_eq!(status, RemoveTestsStatus::MergeConflict);
+            Ok(())
+        })
+        .await.unwrap()
+    }
+
+    async fn add_and_merge_blob(
+        sqlite: &RoswaalSqlite,
+        repo: &RoswaalGitRepository<NoopGitRepositoryClient>,
+        pr_open: &TestGithubPullRequestOpen
+    ) -> Result<()> {
+        let tests_str = "\
+```
+New Test: Blob
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+        _ = AddTestsStatus::from_adding_tests(
+            tests_str,
+            sqlite,
+            pr_open,
+            repo
+        ).await?;
+        _ = MergeBranchStatus::from_merging_branch_with_name(
+            &pr_open.most_recent_head_branch_name().await.unwrap(),
+            &sqlite
+        ).await?;
         Ok(())
+    }
+
+    async fn remove_blob(
+        sqlite: &RoswaalSqlite,
+        repo: &RoswaalGitRepository<NoopGitRepositoryClient>,
+        pr_open: &TestGithubPullRequestOpen
+    ) -> Result<RemoveTestsStatus> {
+        RemoveTestsStatus::from_removing_tests("Blob", sqlite, repo, pr_open).await
     }
 }

--- a/src/operations/remove_tests.rs
+++ b/src/operations/remove_tests.rs
@@ -32,10 +32,7 @@ impl RemoveTestsStatus {
             pr_open,
             async {
                 let removed_test_names = Self::remove_test_names(&test_names, &metadata).await?;
-                let pr = GithubPullRequest::for_removing_test_cases_tif_react_frontend(
-                    &test_names,
-                    &branch_name
-                );
+                let pr = metadata.remove_tests_pull_request(&test_names, &branch_name);
                 Ok((pr, removed_test_names))
             }
         ).await;

--- a/src/tests_data/query.rs
+++ b/src/tests_data/query.rs
@@ -13,21 +13,19 @@ impl <'a> RoswaalSearchTestsQuery<'a> {
         if string.is_empty() {
             Self::AllTests
         } else {
-            Self::TestNames(RoswaalTestNamesString { string })
+            Self::TestNames(RoswaalTestNamesString(string))
         }
     }
 }
 
 /// A list of stringified test names.
 #[derive(Debug, PartialEq, Eq)]
-pub struct RoswaalTestNamesString<'a> {
-    string: &'a str
-}
+pub struct RoswaalTestNamesString<'a>(pub(super) &'a str);
 
 impl <'a> RoswaalTestNamesString<'a> {
     /// Returns an iterator to the test names specified by this string.
     pub fn iter(&self) -> impl Iterator<Item = &'a str> {
-        self.string.lines().filter_map(|line| {
+        self.0.lines().filter_map(|line| {
             let string = line.trim();
             if string.is_empty() {
                 None
@@ -35,6 +33,10 @@ impl <'a> RoswaalTestNamesString<'a> {
                 Some(string)
             }
         })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.iter().count() == 0
     }
 }
 
@@ -70,5 +72,13 @@ The 5 Hounds are too OP Plz Nerf
             "The 5 Hounds are too OP Plz Nerf"
         ];
         assert_eq!(test_names, expected_names)
+    }
+
+    #[test]
+    fn is_empty() {
+        let strings = vec![("", true), ("    ", true), ("\n\n  \n", true), ("h", false)];
+        for (string, is_empty) in strings {
+            assert_eq!(RoswaalTestNamesString(string).is_empty(), is_empty)
+        }
     }
 }

--- a/src/tests_data/query.rs
+++ b/src/tests_data/query.rs
@@ -20,7 +20,7 @@ impl <'a> RoswaalSearchTestsQuery<'a> {
 
 /// A list of stringified test names.
 #[derive(Debug, PartialEq, Eq)]
-pub struct RoswaalTestNamesString<'a>(pub(super) &'a str);
+pub struct RoswaalTestNamesString<'a>(pub &'a str);
 
 impl <'a> RoswaalTestNamesString<'a> {
     /// Returns an iterator to the test names specified by this string.

--- a/src/utils/dedup.rs
+++ b/src/utils/dedup.rs
@@ -1,0 +1,42 @@
+use std::{collections::HashSet, hash::Hash};
+
+/// An iterator for dedupping elements.
+pub struct Dedup<I: Iterator> where I::Item: Hash + Eq + Clone {
+    base: I,
+    set: HashSet<I::Item>
+}
+
+impl <I: Iterator> Iterator for Dedup<I> where I::Item: Hash + Eq + Clone {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(next) = self.base.next() {
+            if !self.set.contains(&next) {
+                self.set.insert(next.clone());
+                return Some(next)
+            }
+        }
+        None
+    }
+}
+
+pub trait DedupIterator: Iterator + Sized where Self::Item: Hash + Eq + Clone {
+    /// Returns an iterator that depuplicates elements.
+    fn dedup(self) -> Dedup<Self> {
+        Dedup { base: self, set: HashSet::new() }
+    }
+}
+
+impl <I: Iterator> DedupIterator for I where I::Item: Hash + Eq + Clone {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_vector_iter() {
+        let nums = vec![1, 2, 3, 3, 3, 4, 1, 3, 2];
+        let deduped = nums.iter().dedup().collect::<Vec<&i32>>();
+        assert_eq!(deduped, vec![&1, &2, &3, &4])
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,3 +3,4 @@ pub mod is_case;
 pub mod normalize;
 pub mod sqlite;
 pub mod fs;
+pub mod dedup;

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -53,6 +53,11 @@ CREATE TABLE IF NOT EXISTS TestSteps (
     UNIQUE(test_id, content),
     CONSTRAINT fk_test FOREIGN KEY(test_id) REFERENCES Tests(id) ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS StagedTestRemovals (
+    name TEXT NOT NULL,
+    unmerged_branch_name TEXT NOT NULL,
+    PRIMARY KEY(name, unmerged_branch_name)
+);
             "
         )
         .execute(pool)


### PR DESCRIPTION
Implements the remove tests operation.

This was done through a `StagedTestRemovals` table that held the test name and branch to delete. Then, when calling the merge operation with a deletion branch the delete is committed. Only merged test cases can be deleted through these means, as the proper way to delete unmerged tests is to close the branch.

I was able to reuse the same format for entering deleted tests, which is contained in the `RoswaalTestNamesString` type.

I also had to make a few changes to `EditGitRepositoryStatus`, the first being that it now has a generic in the success case. Additionally, now callers of the `for_editing_new_branch` function can return a value alongside a `GithubPullRequest`. This was needed because the way we check for what tests were removed is by checking if deleting the respective test directory was successful (which happens during the git transaction), and so a list of those test names who were deleted successfully need to be returned. In addition to the new return value, I also made it automatically delete the branch if the edit failed for some reason. This is because we throw an error in the remove operation if all directory removals failed, and there would be no reason to commit, push, and open a PR in that case. Instead of the operation failing and leaving a dead branch open, it would be better to delete the branch.