### PR TITLE
Close Branch Operation

### DIFF
--- a/src/operations/close_branch.rs
+++ b/src/operations/close_branch.rs
@@ -1,0 +1,35 @@
+use crate::{git::branch_name::{self, RoswaalOwnedBranchKind, RoswaalOwnedGitBranchName}, utils::sqlite::RoswaalSqlite, with_transaction};
+use anyhow::Result;
+
+pub enum CloseBranchStatus<'a> {
+    Closed(RoswaalOwnedBranchKind),
+    UnknownBranchKind(&'a RoswaalOwnedGitBranchName)
+}
+
+impl <'a> CloseBranchStatus<'a> {
+    pub async fn from_closing_branch(
+        branch_name: &'a RoswaalOwnedGitBranchName,
+        sqlite: &RoswaalSqlite
+    ) -> Result<Self> {
+        match branch_name.kind() {
+            Some(kind) => {
+                let mut transaction = sqlite.transaction().await?;
+                with_transaction!(transaction, async {
+                    match kind {
+                        RoswaalOwnedBranchKind::AddTests => {
+                            transaction.close_add_tests_branch(branch_name).await?;
+                        },
+                        RoswaalOwnedBranchKind::AddLocations => {
+                            transaction.close_add_locations_branch(branch_name).await?;
+                        },
+                        RoswaalOwnedBranchKind::RemoveTests => {
+                            transaction.close_remove_tests_branch(branch_name).await?;
+                        }
+                    };
+                    Ok(Self::Closed(kind))
+                })
+            },
+            None => Ok(Self::UnknownBranchKind(branch_name))
+        }
+    }
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -4,3 +4,4 @@ pub mod merge_branch;
 pub mod add_tests;
 pub mod search_tests;
 pub mod remove_tests;
+pub mod close_branch;

--- a/src/operations/search_tests.rs
+++ b/src/operations/search_tests.rs
@@ -26,7 +26,7 @@ impl SearchTestsStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{git::{repo::RoswaalGitRepository, test_support::{with_clean_test_repo_access, TestGithubPullRequestOpen}}, operations::{add_tests::AddTestsStatus, merge_branch::MergeBranchStatus, remove_tests::RemoveTestsStatus}, utils::sqlite::RoswaalSqlite};
+    use crate::{git::{repo::RoswaalGitRepository, test_support::{with_clean_test_repo_access, TestGithubPullRequestOpen}}, operations::{add_tests::AddTestsStatus, close_branch::CloseBranchStatus, merge_branch::MergeBranchStatus, remove_tests::RemoveTestsStatus}, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn reports_no_tests_when_no_tests_saved() {
@@ -124,6 +124,63 @@ Requirement 1: Do the thing
             _ = RemoveTestsStatus::from_removing_tests("bob", &sqlite, &repo, &pr_open).await?;
             branch_name = pr_open.most_recent_head_branch_name().await.unwrap();
             _ = MergeBranchStatus::from_merging_branch_with_name(&branch_name, &sqlite).await?;
+            let query_str = "bob";
+            let status = SearchTestsStatus::from_searching_tests(query_str, &sqlite).await.unwrap();
+            assert_eq!(status, SearchTestsStatus::NoTests);
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_test_is_present_when_removal_branch_merged_after_being_closed() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            let repo = RoswaalGitRepository::noop().await?;
+            let tests_str = "\
+```
+New Test: Bob
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            AddTestsStatus::from_adding_tests(tests_str, &sqlite, &pr_open, &repo).await?;
+            let mut branch_name = pr_open.most_recent_head_branch_name().await.unwrap();
+            MergeBranchStatus::from_merging_branch_with_name(&branch_name, &sqlite).await?;
+            RemoveTestsStatus::from_removing_tests("bob", &sqlite, &repo, &pr_open).await?;
+            branch_name = pr_open.most_recent_head_branch_name().await.unwrap();
+            CloseBranchStatus::from_closing_branch(&branch_name, &sqlite).await?;
+            MergeBranchStatus::from_merging_branch_with_name(&branch_name, &sqlite).await?;
+            let query_str = "bob";
+            let status = SearchTestsStatus::from_searching_tests(query_str, &sqlite).await.unwrap();
+            match status {
+                SearchTestsStatus::Success(tests) => {
+                    assert_eq!(tests[0].name(), "Bob")
+                },
+                _ => panic!()
+            }
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_no_tests_when_no_merged_tests_and_all_unmerged_tests_closed() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            let repo = RoswaalGitRepository::noop().await?;
+            let tests_str = "\
+```
+New Test: Bob
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            AddTestsStatus::from_adding_tests(tests_str, &sqlite, &pr_open, &repo).await?;
+            let branch_name = pr_open.most_recent_head_branch_name().await.unwrap();
+            CloseBranchStatus::from_closing_branch(&branch_name, &sqlite).await?;
             let query_str = "bob";
             let status = SearchTestsStatus::from_searching_tests(query_str, &sqlite).await.unwrap();
             assert_eq!(status, SearchTestsStatus::NoTests);


### PR DESCRIPTION
Implements branch closing by removing DB records that have a matching unmerged branch name. I made the operation similar to `MergeBranchStatus` because its enum cases are similar and how I tested it transitively.