### PR TITLE
Test Progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +178,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "const-oid"
@@ -650,6 +679,29 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1237,6 +1289,7 @@ name = "roswaal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "git2",
  "nanoid",
  "once_cell",
@@ -1522,6 +1575,7 @@ dependencies = [
  "atoi",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -1582,6 +1636,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-mysql",
+ "sqlx-postgres",
  "sqlx-sqlite",
  "syn 1.0.109",
  "tempfile",
@@ -1600,6 +1655,7 @@ dependencies = [
  "bitflags 2.5.0",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -1641,6 +1697,7 @@ dependencies = [
  "base64 0.21.7",
  "bitflags 2.5.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -1676,6 +1733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -2130,6 +2188,15 @@ checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
  "redox_syscall 0.4.1",
  "wasite",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"
+chrono = "0.4.38"
 git2 = "0.19.0"
 nanoid = "0.4.0"
 once_cell = "1.19.0"
@@ -14,7 +15,12 @@ regex = "1.10.4"
 reqwest = { version = "0.12.4", features = ["json"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
-sqlx = { version = "0.7.4", features = ["runtime-tokio", "sqlite", "macros"] }
+sqlx = { version = "0.7.4", features = [
+    "runtime-tokio",
+    "sqlite",
+    "macros",
+    "chrono",
+] }
 strum = "0.26.2"
 strum_macros = "0.26.2"
 tokio = { version = "1.38.0", features = ["rt", "macros", "process", "sync"] }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -5,3 +5,4 @@ pub mod add_tests;
 pub mod search_tests;
 pub mod remove_tests;
 pub mod close_branch;
+pub mod save_progress;

--- a/src/operations/save_progress.rs
+++ b/src/operations/save_progress.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+
+use crate::{tests_data::progress::RoswaalTestProgress, utils::sqlite::RoswaalSqlite, with_transaction};
+
+pub async fn save_test_progress(
+    progress: &Vec<RoswaalTestProgress>,
+    sqlite: &RoswaalSqlite
+) -> Result<()> {
+    let mut transaction = sqlite.transaction().await?;
+    with_transaction!(transaction, async { transaction.save_test_progess(progress).await })
+}

--- a/src/operations/search_tests.rs
+++ b/src/operations/search_tests.rs
@@ -26,7 +26,7 @@ impl SearchTestsStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{git::{repo::RoswaalGitRepository, test_support::{with_clean_test_repo_access, TestGithubPullRequestOpen}}, operations::{add_tests::AddTestsStatus, close_branch::CloseBranchStatus, merge_branch::MergeBranchStatus, remove_tests::RemoveTestsStatus}, utils::sqlite::RoswaalSqlite};
+    use crate::{git::{repo::RoswaalGitRepository, test_support::{with_clean_test_repo_access, TestGithubPullRequestOpen}}, operations::{add_tests::AddTestsStatus, close_branch::CloseBranchStatus, merge_branch::MergeBranchStatus, remove_tests::RemoveTestsStatus, save_progress::save_test_progress}, tests_data::{ordinal::RoswaalTestCommandOrdinal, progress::RoswaalTestProgress}, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn reports_no_tests_when_no_tests_saved() {
@@ -184,6 +184,43 @@ Requirement 1: Do the thing
             let query_str = "bob";
             let status = SearchTestsStatus::from_searching_tests(query_str, &sqlite).await.unwrap();
             assert_eq!(status, SearchTestsStatus::NoTests);
+            Ok(())
+        })
+        .await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_tests_with_updated_progress() {
+        with_clean_test_repo_access(async {
+            let sqlite = RoswaalSqlite::in_memory().await?;
+            let pr_open = TestGithubPullRequestOpen::new(false);
+            let repo = RoswaalGitRepository::noop().await?;
+            let tests_str = "\
+```
+New Test: Bob
+Step 1: Do the thing
+Requirement 1: Do the thing
+```
+";
+            AddTestsStatus::from_adding_tests(tests_str, &sqlite, &pr_open, &repo).await?;
+            let branch_name = pr_open.most_recent_head_branch_name().await.unwrap();
+            MergeBranchStatus::from_merging_branch_with_name(&branch_name, &sqlite).await?;
+            let progress = vec![
+                RoswaalTestProgress::new(
+                    "Bob".to_string(),
+                    Some(RoswaalTestCommandOrdinal::new(0)),
+                    None
+                )
+            ];
+            save_test_progress(&progress, &sqlite).await?;
+            let query_str = "bob";
+            let status = SearchTestsStatus::from_searching_tests(query_str, &sqlite).await.unwrap();
+            match status {
+                SearchTestsStatus::Success(tests) => {
+                    assert_eq!(tests[0].command_failure_ordinal(), Some(RoswaalTestCommandOrdinal::new(0)))
+                },
+                _ => panic!()
+            };
             Ok(())
         })
         .await.unwrap();

--- a/src/tests_data/mod.rs
+++ b/src/tests_data/mod.rs
@@ -1,3 +1,4 @@
 pub mod progress;
 pub mod storage;
 pub mod query;
+pub mod ordinal;

--- a/src/tests_data/ordinal.rs
+++ b/src/tests_data/ordinal.rs
@@ -1,0 +1,30 @@
+use serde::Deserialize;
+use sqlx::{prelude::Type, sqlite::SqliteTypeInfo, Decode, Encode, Sqlite};
+
+/// An ordinal that represents the index of a step in a test case.
+///
+/// Each test case has a before launch step which gets the special zero ordinal that can be
+/// obtained through the `for_before_launch` constructor.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Encode, Decode)]
+pub struct RoswaalTestCommandOrdinal(i32);
+
+impl RoswaalTestCommandOrdinal {
+    /// The ordinal for a test's before launch command.
+    pub fn for_before_launch() -> Self {
+        Self(0)
+    }
+
+    /// The ordinal for the index of a command in the list of test commands.
+    ///
+    /// The index should correspond directly to the position of the command in a vector of commands
+    /// that does not include the before launch command.
+    pub fn new(command_index: i32) -> Self {
+        Self(command_index + 1)
+    }
+}
+
+impl Type<Sqlite> for RoswaalTestCommandOrdinal {
+    fn type_info() -> SqliteTypeInfo {
+        <i32 as Type<Sqlite>>::type_info()
+    }
+}

--- a/src/tests_data/progress.rs
+++ b/src/tests_data/progress.rs
@@ -1,19 +1,56 @@
 use serde::Deserialize;
 
+use super::ordinal::RoswaalTestCommandOrdinal;
+
+/// The progress of a test case.
+///
+/// Each test runs its commands sequentially, and reports a failure on the ordinal of the command.
+/// Note that the zero ordinal denotes the before launch command, which every test implicity has.
 #[derive(Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RoswaalTestProgress {
     test_name: String,
-    results: Vec<RoswaalTestProgressResult>,
+    command_failure_ordinal: Option<RoswaalTestCommandOrdinal>,
     error: Option<RoswaalTestProgressErrorDescription>
 }
 
+impl RoswaalTestProgress {
+    pub fn new(
+        test_name: String,
+        command_failure_ordinal: Option<RoswaalTestCommandOrdinal>,
+        error: Option<RoswaalTestProgressErrorDescription>
+    ) -> Self {
+        Self { test_name, command_failure_ordinal, error }
+    }
+}
+
+impl RoswaalTestProgress {
+    pub fn command_failure_ordinal(&self) -> Option<RoswaalTestCommandOrdinal> {
+        self.command_failure_ordinal
+    }
+
+    pub fn test_name(&self) -> &str {
+        &self.test_name
+    }
+
+    pub fn error_message(&self) -> Option<&String> {
+        self.error.as_ref().map(|e| &e.message)
+    }
+
+    pub fn error_stack_trace(&self) -> Option<&String> {
+        self.error.as_ref().map(|e| &e.stack_trace)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RoswaalTestProgressErrorDescription {
     message: String,
     stack_trace: String
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize)]
-pub struct RoswaalTestProgressResult {
-    did_pass: bool
+impl RoswaalTestProgressErrorDescription {
+    pub fn new(message: String, stack_trace: String) -> Self {
+        Self { message, stack_trace }
+    }
 }

--- a/src/tests_data/storage.rs
+++ b/src/tests_data/storage.rs
@@ -20,6 +20,10 @@ impl RoswaalStoredTest {
     pub fn name(&self) -> &str {
         &self.name
     }
+
+    pub fn command_failure_ordinal(&self) -> Option<RoswaalTestCommandOrdinal> {
+        self.command_failure_ordinal
+    }
 }
 
 impl <'a> RoswaalSqliteTransaction<'a> {

--- a/src/tests_data/storage.rs
+++ b/src/tests_data/storage.rs
@@ -4,13 +4,14 @@ use crate::{git::branch_name::{self, RoswaalOwnedGitBranchName}, language::test:
 use anyhow::Result;
 use sqlx::{query, query_as, FromRow, Sqlite};
 
-use super::{progress::RoswaalTestProgressErrorDescription, query::{RoswaalSearchTestsQuery, RoswaalTestNamesString}};
+use super::{ordinal::RoswaalTestCommandOrdinal, progress::{RoswaalTestProgress, RoswaalTestProgressErrorDescription}, query::{RoswaalSearchTestsQuery, RoswaalTestNamesString}};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct RoswaalStoredTest {
     name: String,
     description: Option<String>,
-    steps: Vec<RoswaalStoredTestCommand>,
+    steps: Vec<RoswaalTestCommand>,
+    command_failure_ordinal: Option<RoswaalTestCommandOrdinal>,
     error: Option<RoswaalTestProgressErrorDescription>,
     unmerged_branch_name: Option<RoswaalOwnedGitBranchName>
 }
@@ -21,13 +22,24 @@ impl RoswaalStoredTest {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct RoswaalStoredTestCommand {
-    command: RoswaalTestCommand,
-    did_pass: bool
-}
-
 impl <'a> RoswaalSqliteTransaction<'a> {
+    pub async fn save_test_progess(
+        &mut self,
+        progress: &Vec<RoswaalTestProgress>
+    ) -> Result<()> {
+        sqlite_repeat(statements::UPDATE_TEST_PROGRESS, progress)
+            .bind_to_query(|q, progress| {
+                Ok(
+                    q.bind(progress.command_failure_ordinal())
+                        .bind(progress.error_message())
+                        .bind(progress.error_stack_trace())
+                        .bind(progress.test_name()))
+            })?
+            .execute(self.connection())
+            .await?;
+        Ok(())
+    }
+
     pub async fn close_remove_tests_branch(
         &mut self,
         branch_name: &RoswaalOwnedGitBranchName
@@ -122,8 +134,9 @@ impl <'a> RoswaalSqliteTransaction<'a> {
             &(0..tests.iter().flat_map(|t| t.commands()).count()).collect()
         )
         .bind_custom_values_to_query(zip(tests.iter(), id_rows.iter()), |mut q, (test, id_row)| {
-            for (ordinal, command) in test.commands().iter().enumerate() {
-                q = q.bind(id_row.id).bind(serde_json::to_string(&command)?).bind(ordinal as i32)
+            for (raw_ordinal, command) in test.commands().iter().enumerate() {
+                let ordinal = RoswaalTestCommandOrdinal::new(raw_ordinal as i32);
+                q = q.bind(id_row.id).bind(serde_json::to_string(&command)?).bind(ordinal)
             }
             Ok(q)
         })?
@@ -153,31 +166,37 @@ impl <'a> RoswaalSqliteTransaction<'a> {
             }
         };
         if sqlite_tests.is_empty() { return Ok(vec![]) }
-        let mut test = RoswaalStoredTest {
-            name: sqlite_tests[0].test_name.clone(),
-            description: sqlite_tests[0].description.clone(),
-            steps: vec![],
-            unmerged_branch_name: sqlite_tests[0].unmerged_branch_name.clone(),
-            error: None
-        };
+        let mut test = RoswaalStoredTest::from_sqlite_row(&sqlite_tests[0], vec![]);
         let mut tests = Vec::<RoswaalStoredTest>::new();
         for sqlite_test in sqlite_tests {
             let command = serde_json::from_str::<RoswaalTestCommand>(&sqlite_test.command_content)?;
             if sqlite_test.is_separate_from(&test) {
                 tests.push(test);
-                test = RoswaalStoredTest {
-                    name: sqlite_test.test_name.clone(),
-                    description: sqlite_test.description.clone(),
-                    steps: vec![RoswaalStoredTestCommand { command, did_pass: sqlite_test.did_pass }],
-                    unmerged_branch_name: sqlite_test.unmerged_branch_name.clone(),
-                    error: None
-                };
+                test = RoswaalStoredTest::from_sqlite_row(&sqlite_test, vec![command]);
             } else {
-                test.steps.push(RoswaalStoredTestCommand { command, did_pass: sqlite_test.did_pass })
+                test.steps.push(command)
             };
         }
         tests.push(test);
         Ok(tests)
+    }
+}
+
+impl RoswaalStoredTest {
+    fn from_sqlite_row(sqlite_test: &SqliteStoredTestRow, steps: Vec<RoswaalTestCommand>) -> Self {
+        let error = (sqlite_test.error_message.clone(), sqlite_test.error_stack_trace.clone());
+        Self {
+            name: sqlite_test.test_name.clone(),
+            description: sqlite_test.description.clone(),
+            steps,
+            unmerged_branch_name: sqlite_test.unmerged_branch_name.clone(),
+            command_failure_ordinal: sqlite_test.command_failure_ordinal,
+            error: if let (Some(m), Some(s)) = error {
+                Some(RoswaalTestProgressErrorDescription::new(m, s))
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -199,8 +218,10 @@ SELECT
     t.name AS test_name,
     t.description,
     t.unmerged_branch_name,
-    c.content AS command_content,
-    c.did_pass
+    t.command_failure_ordinal,
+    t.error_message,
+    t.error_stack_trace,
+    c.content AS command_content
 FROM Tests t
 INNER JOIN TestSteps c ON t.id = c.test_id
 ORDER BY test_name, c.ordinal;
@@ -232,24 +253,36 @@ INSERT OR REPLACE INTO Tests (
 ) RETURNING id;";
 
     pub const DELETE_STAGED_TEST_REMOVALS_WITH_BRANCH: &str =
-        "DELETE FROM StagedTestRemovals WHERE unmerged_branch_name = ?";
+        "DELETE FROM StagedTestRemovals WHERE unmerged_branch_name = ?;";
 
     pub const DELETE_UNMERGED_TESTS_WITH_BRANCH: &str =
-        "DELETE FROM Tests WHERE unmerged_branch_name = ?";
+        "DELETE FROM Tests WHERE unmerged_branch_name = ?;";
+
+    pub const UPDATE_TEST_PROGRESS: &str = "\
+UPDATE Tests
+SET
+    command_failure_ordinal = ?,
+    error_message = ?,
+    error_stack_trace = ?
+WHERE
+    name = ? AND unmerged_branch_name IS NULL;
+";
 
     pub fn select_tests_in_alphabetical_order(count: usize) -> String {
         format!("
-    SELECT
-        t.name AS test_name,
-        t.description,
-        t.unmerged_branch_name,
-        c.content AS command_content,
-        c.did_pass
-    FROM Tests t
-    INNER JOIN TestSteps c ON t.id = c.test_id
-    WHERE LOWER(test_name) IN {}
-    ORDER BY test_name, c.ordinal;
-    ", sqlite_array_fields(count))
+SELECT
+    t.name AS test_name,
+    t.description,
+    t.unmerged_branch_name,
+    t.command_failure_ordinal,
+    t.error_message,
+    t.error_stack_trace,
+    c.content AS command_content
+FROM Tests t
+INNER JOIN TestSteps c ON t.id = c.test_id
+WHERE LOWER(test_name) IN {}
+ORDER BY test_name, c.ordinal;
+", sqlite_array_fields(count))
     }
 
     pub fn delete_tests(count: usize) -> String {
@@ -276,7 +309,9 @@ struct SqliteStoredTestRow {
     description: Option<String>,
     unmerged_branch_name: Option<RoswaalOwnedGitBranchName>,
     command_content: String,
-    did_pass: bool
+    command_failure_ordinal: Option<RoswaalTestCommandOrdinal>,
+    error_message: Option<String>,
+    error_stack_trace: Option<String>
 }
 
 impl SqliteStoredTestRow {
@@ -290,7 +325,7 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::{git::branch_name::{self, RoswaalOwnedGitBranchName}, language::test::{RoswaalTest, RoswaalTestCommand}, location::name::RoswaalLocationName, utils::sqlite::RoswaalSqlite};
+    use crate::{git::branch_name::{self, RoswaalOwnedGitBranchName}, language::test::{RoswaalTest, RoswaalTestCommand}, location::name::RoswaalLocationName, tests_data::{ordinal::RoswaalTestCommandOrdinal}, utils::sqlite::RoswaalSqlite};
 
     #[tokio::test]
     async fn test_store_and_retrieve_unmerged_tests() {
@@ -331,36 +366,29 @@ mod tests {
                 name: "Test 1".to_string(),
                 description: None,
                 steps: vec![
-                    RoswaalStoredTestCommand {
-                        command: RoswaalTestCommand::Step {
-                            name: "Step 1".to_string(),
-                            requirement: "Requirement 1".to_string()
-                        },
-                        did_pass: false
+                    RoswaalTestCommand::Step {
+                        name: "Step 1".to_string(),
+                        requirement: "Requirement 1".to_string()
                     },
-                    RoswaalStoredTestCommand {
-                        command: RoswaalTestCommand::SetLocation {
-                            location_name: RoswaalLocationName::from_str("test").unwrap()
-                        },
-                        did_pass: false
+                    RoswaalTestCommand::SetLocation {
+                        location_name: RoswaalLocationName::from_str("test").unwrap()
                     }
                 ],
                 error: None,
+                command_failure_ordinal: None,
                 unmerged_branch_name: Some(branch_name.clone())
             },
             RoswaalStoredTest {
                 name: "Test 2".to_string(),
                 description: None,
                 steps: vec![
-                    RoswaalStoredTestCommand {
-                        command: RoswaalTestCommand::Step {
-                            name: "Step A".to_string(),
-                            requirement: "Requirement A".to_string()
-                        },
-                        did_pass: false
+                    RoswaalTestCommand::Step {
+                        name: "Step A".to_string(),
+                        requirement: "Requirement A".to_string()
                     }
                 ],
                 error: None,
+                command_failure_ordinal: None,
                 unmerged_branch_name: Some(branch_name.clone())
             }
         ];
@@ -406,15 +434,13 @@ mod tests {
                 name: "Test".to_string(),
                 description: None,
                 steps: vec![
-                    RoswaalStoredTestCommand {
-                        command: RoswaalTestCommand::Step {
-                            name: "Step A".to_string(),
-                            requirement: "Requirement A".to_string()
-                        },
-                        did_pass: false
+                    RoswaalTestCommand::Step {
+                        name: "Step A".to_string(),
+                        requirement: "Requirement A".to_string()
                     }
                 ],
                 error: None,
+                command_failure_ordinal: None,
                 unmerged_branch_name: Some(branch_name.clone())
             }
         ];
@@ -461,30 +487,26 @@ mod tests {
                 name: "Test".to_string(),
                 description: None,
                 steps: vec![
-                    RoswaalStoredTestCommand {
-                        command: RoswaalTestCommand::Step {
-                            name: "Step 1".to_string(),
-                            requirement: "Requirement 1".to_string()
-                        },
-                        did_pass: false
+                    RoswaalTestCommand::Step {
+                        name: "Step 1".to_string(),
+                        requirement: "Requirement 1".to_string()
                     }
                 ],
                 error: None,
+                command_failure_ordinal: None,
                 unmerged_branch_name: Some(branch_name1.clone())
             },
             RoswaalStoredTest {
                 name: "Test".to_string(),
                 description: None,
                 steps: vec![
-                    RoswaalStoredTestCommand {
-                        command: RoswaalTestCommand::Step {
-                            name: "Step A".to_string(),
-                            requirement: "Requirement A".to_string()
-                        },
-                        did_pass: false
+                    RoswaalTestCommand::Step {
+                        name: "Step A".to_string(),
+                        requirement: "Requirement A".to_string()
                     }
                 ],
                 error: None,
+                command_failure_ordinal: None,
                 unmerged_branch_name: Some(branch_name2.clone())
             }
         ];
@@ -591,16 +613,14 @@ mod tests {
                 name: "Test".to_string(),
                 description: None,
                 steps: vec![
-                    RoswaalStoredTestCommand {
-                        command: RoswaalTestCommand::Step {
-                            name: "Step A".to_string(),
-                            requirement: "Requirement A".to_string()
-                        },
-                        did_pass: false
+                    RoswaalTestCommand::Step {
+                        name: "Step A".to_string(),
+                        requirement: "Requirement A".to_string()
                     }
                 ],
                 error: None,
-                unmerged_branch_name: None
+                unmerged_branch_name: None,
+                command_failure_ordinal: None
             }
         ];
         assert_eq!(stored_tests, expected_tests)
@@ -839,5 +859,83 @@ L
         ).await.unwrap();
         let expected_test_names = vec!["Zanza The Divine"];
         assert_eq!(stored_tests.iter().map(|t| t.name()).collect::<Vec<&str>>(), expected_test_names)
+    }
+
+    #[tokio::test]
+    async fn saves_test_progress_for_merged_tests() {
+        let branch_name = RoswaalOwnedGitBranchName::new("test");
+        let sqlite = RoswaalSqlite::in_memory().await.unwrap();
+        let mut transaction = sqlite.transaction().await.unwrap();
+        let mut tests = vec![
+            RoswaalTest::new(
+                "Dazai Is Insane".to_string(),
+                None,
+                vec![
+                    RoswaalTestCommand::Step {
+                        name: "Step 1".to_string(),
+                        requirement: "Requirement 1".to_string()
+                    },
+                    RoswaalTestCommand::SetLocation {
+                        location_name: RoswaalLocationName::from_str("test").unwrap()
+                    }
+                ]
+            ),
+            RoswaalTest::new(
+                "Zanza The Divine".to_string(),
+                None,
+                vec![
+                    RoswaalTestCommand::Step {
+                        name: "Step A".to_string(),
+                        requirement: "Requirement A".to_string()
+                    }
+                ]
+            )
+        ];
+        transaction.save_tests(&tests, &branch_name).await.unwrap();
+        transaction.merge_unmerged_tests(&branch_name).await.unwrap();
+        let branch_name2 = RoswaalOwnedGitBranchName::new("test-2");
+        tests = vec![
+            RoswaalTest::new(
+                "Zanza The Divine".to_string(),
+                None,
+                vec![
+                    RoswaalTestCommand::Step {
+                        name: "Step B".to_string(),
+                        requirement: "Requirement C".to_string()
+                    }
+                ]
+            )
+        ];
+        transaction.save_tests(&tests, &branch_name2).await.unwrap();
+
+        let progress = vec![
+            RoswaalTestProgress::new(
+                "Zanza The Divine".to_string(),
+                Some(RoswaalTestCommandOrdinal::new(0)),
+                Some(
+                    RoswaalTestProgressErrorDescription::new(
+                        "Device died".to_string(),
+                        "Some stack trace...".to_string()
+                    )
+                )
+            ),
+            RoswaalTestProgress::new(
+                "Dazai Is Insane".to_string(),
+                None,
+                None
+            )
+        ];
+        transaction.save_test_progess(&progress).await.unwrap();
+        let stored_tests = transaction.tests_in_alphabetical_order(
+            &RoswaalSearchTestsQuery::AllTests
+        )
+        .await
+        .unwrap();
+        assert_eq!(stored_tests[0].command_failure_ordinal, None);
+        assert_eq!(stored_tests[1].command_failure_ordinal, Some(RoswaalTestCommandOrdinal::new(0)));
+        assert_eq!(stored_tests[2].command_failure_ordinal, None);
+        assert!(stored_tests[0].error.is_none());
+        assert!(stored_tests[1].error.is_some());
+        assert!(stored_tests[2].error.is_none());
     }
 }

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS Tests (
     error_stack_trace TEXT,
     command_failure_ordinal INTEGER,
     creation_date DATETIME NOT NULL DEFAULT (unixepoch()),
+    last_run_date DATETIME,
     UNIQUE(name, unmerged_branch_name)
 );
 CREATE TABLE IF NOT EXISTS TestSteps (

--- a/src/utils/sqlite.rs
+++ b/src/utils/sqlite.rs
@@ -42,6 +42,9 @@ CREATE TABLE IF NOT EXISTS Tests (
     name TEXT NOT NULL,
     description TEXT,
     unmerged_branch_name TEXT,
+    error_message TEXT,
+    error_stack_trace TEXT,
+    command_failure_ordinal INTEGER,
     creation_date DATETIME NOT NULL DEFAULT (unixepoch()),
     UNIQUE(name, unmerged_branch_name)
 );
@@ -50,7 +53,6 @@ CREATE TABLE IF NOT EXISTS TestSteps (
     test_id INTEGER NOT NULL,
     content TEXT NOT_NULL,
     ordinal INTEGER NOT NULL,
-    did_pass INT2 NOT NULL DEFAULT FALSE,
     creation_date DATETIME NOT NULL DEFAULT (unixepoch()),
     UNIQUE(test_id, content),
     CONSTRAINT fk_test FOREIGN KEY(test_id) REFERENCES Tests(id) ON DELETE CASCADE
@@ -58,6 +60,7 @@ CREATE TABLE IF NOT EXISTS TestSteps (
 CREATE TABLE IF NOT EXISTS StagedTestRemovals (
     name TEXT NOT NULL,
     unmerged_branch_name TEXT NOT NULL,
+    creation_date DATETIME NOT NULL DEFAULT (unixepoch()),
     PRIMARY KEY(name, unmerged_branch_name)
 );
             "


### PR DESCRIPTION
Implements test progress saving. The type for saving progress is `RoswaalTestProgress` which can be deserialized from JSON uploaded by the frontend repo after running all the acceptance tests.

Each test has a command failure ordinal that is represented by the `RoswaalTestCommandOrdinal` type. This ordinal represents the index of the command at which the test failed, plus the implicit before-launch command. The zero ordinal is reserved for the before-launch command, and it can be constructed via the `for_before_launch` constructor.

I also added a `last_run_date` field which can be used in the UI to distinguish if a newly added test has been ran or not since all the failure properties would be null for a newly added (but not passing) test. This way, we can judge if a test passed by seeing whether or not it has no recorded errors, *and* if it has a last run date.