### PR TITLE
Fix .env loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GITHUB_API_KEY=**********
+TEST_SSH_PRIVATE_KEY_HOME_PATH=./.ssh/id_rsa

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1296,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "dotenv",
  "git2",
  "nanoid",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 chrono = "0.4.38"
+dotenv = "0.15.0"
 git2 = "0.19.0"
 nanoid = "0.4.0"
 once_cell = "1.19.0"

--- a/reset_test_repo.sh
+++ b/reset_test_repo.sh
@@ -10,17 +10,6 @@ exit_with_failure_if_needed() {
 }
 
 echo "🔵 Resetting Test Repo"
-if [ ! -f .env ]; then
-    echo "🔴 No .env file found. Make sure to create a .env file with the TEST_SSH_PRIVATE_KEY_HOME_PATH set to the path of your private ssh key."
-    exit_with_failure_if_needed
-fi
-while IFS= read -r line || [ -n "$line" ]; do
-    # Ignore lines that are comments or empty
-    if [[ ! $line =~ ^#.* ]] && [[ -n $line ]]; then
-      # Export the variable
-      export $line
-    fi
-done < .env
 cd FitnessProjectTest
 git commit --allow-empty -n -m "No unborn branches ensured..." > /dev/null 2> /dev/null
 git branch --show-current

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -5,6 +5,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use once_cell::sync::Lazy;
 use std::future::Future;
 use tokio::process::Command;
+use dotenv::dotenv;
 
 #[cfg(test)]
 use tokio::sync::Mutex;
@@ -152,6 +153,7 @@ static TEST_REPO_LOCK: Lazy<Arc<Mutex<()>>> = Lazy::new(|| Arc::new(Mutex::new((
 #[cfg(test)]
 pub async fn with_clean_test_repo_access(work: impl Future<Output = Result<()>>) -> Result<()> {
     let guard = TEST_REPO_LOCK.lock().await;
+    dotenv()?;
     Command::new("./reset_test_repo.sh").spawn()?.wait().await?;
     let result = work.await;
     drop(guard);


### PR DESCRIPTION
Turns out that exporting the .env values from a shell script didn't work in the long run. It only worked for me because I had manually run `source ./reset_test_repo.sh` before running any tests.

So I decided to install the dotenv crate to fix that.