### PR TITLE
Slack: More UI Framework Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .env
 /FitnessProject
 /FitnessProjectTest
+/slack-snapshot-diffs

--- a/slack-snapshots/test-snapshot.json
+++ b/slack-snapshots/test-snapshot.json
@@ -1,0 +1,1 @@
+{"blocks":[{"text":{"text":"I am a test view","type":"mrkdwn"},"type":"section"}]}

--- a/src/slack/ui_lib/any_view.rs
+++ b/src/slack/ui_lib/any_view.rs
@@ -1,0 +1,32 @@
+use super::{blocks::_SlackBlocks, primitive_view::_PrimitiveView, slack_view::{find_primitive_view, SlackView}};
+
+/// A type-erased view.
+pub struct AnySlackView {
+    inner: _PrimitiveView
+}
+
+impl AnySlackView {
+    /// Erases the specified view.
+    pub fn erasing(view: impl SlackView) -> Self {
+        Self { inner: find_primitive_view(&view) }
+    }
+
+    /// Erases a reference to the specified view.
+    pub fn erasing_ref(view: &impl SlackView) -> Self {
+        Self { inner: find_primitive_view(view) }
+    }
+}
+
+impl SlackView for AnySlackView {
+    fn _as_primitive_view(&self) -> Option<_PrimitiveView> {
+        Some(self.inner.clone())
+    }
+
+    fn _push_blocks_into(&self, slack_blocks: &mut _SlackBlocks) where Self: Sized {
+        slack_blocks.push_primitive_view(&self.inner)
+    }
+
+    fn slack_body(&self) -> impl SlackView {
+        self.inner.slack_body()
+    }
+}

--- a/src/slack/ui_lib/block_kit_views.rs
+++ b/src/slack/ui_lib/block_kit_views.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use serde::Serialize;
 
-use super::{primitive_view::PrimitiveView, slack_view::SlackView};
+use super::{primitive_view::_PrimitiveView, slack_view::SlackView};
 
 /// A section component.
 #[derive(Debug, PartialEq, Eq, Serialize)]
@@ -24,7 +24,7 @@ impl SlackSection {
 
 impl SlackView for SlackSection {
     fn slack_body(&self) -> impl SlackView {
-        PrimitiveView::new(self)
+        _PrimitiveView::new(self)
     }
 }
 
@@ -54,7 +54,7 @@ pub const SlackDivider: _SlackDivider = _SlackDivider { _type: "divider" };
 
 impl SlackView for _SlackDivider {
     fn slack_body(&self) -> impl SlackView {
-        PrimitiveView::new(self)
+        _PrimitiveView::new(self)
     }
 }
 

--- a/src/slack/ui_lib/blocks.rs
+++ b/src/slack/ui_lib/blocks.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use super::{primitive_view::PrimitiveView, slack_view::SlackView};
+use super::{primitive_view::_PrimitiveView, slack_view::SlackView};
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct _SlackBlocks(Vec<serde_json::Value>);
@@ -16,7 +16,7 @@ impl _SlackBlocks {
         view.slack_body()._push_blocks_into(self)
     }
 
-    pub(super) fn push_primitive_view(&mut self, view: &PrimitiveView) {
+    pub(super) fn push_primitive_view(&mut self, view: &_PrimitiveView) {
         if let Some(value) = view.json_value() {
             self.0.push(value.clone())
         }

--- a/src/slack/ui_lib/blocks.rs
+++ b/src/slack/ui_lib/blocks.rs
@@ -2,6 +2,19 @@ use serde::Serialize;
 
 use super::{primitive_view::_PrimitiveView, slack_view::SlackView};
 
+/// A struct to render a `SlackView` into a flat array of serialized slack blocks.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct SlackBlocks(Vec<serde_json::Value>);
+
+impl SlackBlocks {
+    /// Renders the specified view into a `SlackBlocks` instance.
+    pub fn render(view: &impl SlackView) -> Self {
+        let mut blocks = _SlackBlocks::new();
+        view._push_blocks_into(&mut blocks);
+        Self(blocks.0)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct _SlackBlocks(Vec<serde_json::Value>);
 

--- a/src/slack/ui_lib/empty_view.rs
+++ b/src/slack/ui_lib/empty_view.rs
@@ -1,12 +1,16 @@
-use super::{primitive_view::PrimitiveView, slack_view::SlackView};
+use super::{primitive_view::_PrimitiveView, slack_view::SlackView};
 
 /// A view to use as a placeholder when no other view can be returned from the `slack_body` method
 /// of another view.
-pub struct EmptyView;
+pub struct EmptySlackView;
 
-impl SlackView for EmptyView {
+impl SlackView for EmptySlackView {
+    fn _as_primitive_view(&self) -> Option<_PrimitiveView> {
+        Some(_PrimitiveView::empty())
+    }
+
     fn slack_body(&self) -> impl SlackView {
-        PrimitiveView::empty()
+        _PrimitiveView::empty()
     }
 }
 
@@ -14,7 +18,7 @@ impl SlackView for EmptyView {
 mod tests {
     use crate::slack::ui_lib::{block_kit_views::SlackSection, slack_view::SlackView, test_support::assert_blocks_json};
 
-    use super::EmptyView;
+    use super::EmptySlackView;
 
     struct View;
 
@@ -28,7 +32,7 @@ mod tests {
 
     impl SlackView for ChainWithEmptyView {
         fn slack_body(&self) -> impl SlackView {
-            View.flat_chain_block(EmptyView)
+            View.flat_chain_block(EmptySlackView)
         }
     }
 

--- a/src/slack/ui_lib/empty_view.rs
+++ b/src/slack/ui_lib/empty_view.rs
@@ -1,0 +1,42 @@
+use super::{primitive_view::PrimitiveView, slack_view::SlackView};
+
+/// A view to use as a placeholder when no other view can be returned from the `slack_body` method
+/// of another view.
+pub struct EmptyView;
+
+impl SlackView for EmptyView {
+    fn slack_body(&self) -> impl SlackView {
+        PrimitiveView::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::slack::ui_lib::{block_kit_views::SlackSection, slack_view::SlackView, test_support::assert_blocks_json};
+
+    use super::EmptyView;
+
+    struct View;
+
+    impl SlackView for View {
+        fn slack_body(&self) -> impl SlackView {
+            SlackSection::from_markdown("I am bob!")
+        }
+    }
+
+    struct ChainWithEmptyView;
+
+    impl SlackView for ChainWithEmptyView {
+        fn slack_body(&self) -> impl SlackView {
+            View.flat_chain_block(EmptyView)
+        }
+    }
+
+    #[test]
+    fn does_not_insert_block() {
+        assert_blocks_json(
+            &ChainWithEmptyView,
+            r#"[{"text":{"text":"I am bob!","type":"mrkdwn"},"type":"section"}]"#
+        )
+    }
+}

--- a/src/slack/ui_lib/flat_chain_view.rs
+++ b/src/slack/ui_lib/flat_chain_view.rs
@@ -1,4 +1,4 @@
-use super::{blocks::_SlackBlocks, primitive_view::PrimitiveView, slack_view::SlackView};
+use super::{blocks::_SlackBlocks, empty_view::EmptyView, primitive_view::PrimitiveView, slack_view::SlackView};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct _FlatChainSlackView<Base: SlackView, Other: SlackView> {
@@ -15,7 +15,9 @@ impl <Base: SlackView + 'static, Other: SlackView + 'static>
 
 impl <Base: SlackView + 'static, Other: SlackView + 'static> SlackView
     for _FlatChainSlackView<Base, Other> {
-    fn slack_body(&self) -> impl SlackView { PrimitiveView::empty() }
+    fn slack_body(&self) -> impl SlackView {
+        EmptyView
+    }
 
     fn _push_blocks_into(&self, slack_blocks: &mut _SlackBlocks) {
         self.base._push_blocks_into(slack_blocks);

--- a/src/slack/ui_lib/flat_chain_view.rs
+++ b/src/slack/ui_lib/flat_chain_view.rs
@@ -1,4 +1,4 @@
-use super::{blocks::_SlackBlocks, empty_view::EmptyView, primitive_view::PrimitiveView, slack_view::SlackView};
+use super::{blocks::_SlackBlocks, empty_view::EmptySlackView, slack_view::SlackView};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct _FlatChainSlackView<Base: SlackView, Other: SlackView> {
@@ -6,17 +6,15 @@ pub struct _FlatChainSlackView<Base: SlackView, Other: SlackView> {
     other: Other
 }
 
-impl <Base: SlackView + 'static, Other: SlackView + 'static>
-    _FlatChainSlackView<Base, Other> {
+impl <Base: SlackView, Other: SlackView> _FlatChainSlackView<Base, Other> {
     pub(super) fn new(base: Base, other: Other) -> Self {
         Self { base, other }
     }
 }
 
-impl <Base: SlackView + 'static, Other: SlackView + 'static> SlackView
-    for _FlatChainSlackView<Base, Other> {
+impl <Base: SlackView, Other: SlackView> SlackView for _FlatChainSlackView<Base, Other> {
     fn slack_body(&self) -> impl SlackView {
-        EmptyView
+        EmptySlackView
     }
 
     fn _push_blocks_into(&self, slack_blocks: &mut _SlackBlocks) {

--- a/src/slack/ui_lib/message.rs
+++ b/src/slack/ui_lib/message.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use super::{blocks::_SlackBlocks, slack_view::SlackView};
+use super::{blocks::{SlackBlocks, _SlackBlocks}, slack_view::SlackView};
 
 /// A slack message.
 ///
@@ -9,7 +9,7 @@ use super::{blocks::_SlackBlocks, slack_view::SlackView};
 pub struct SlackMessage {
     #[serde(rename = "channel")]
     channel_id: String,
-    blocks: _SlackBlocks
+    blocks: SlackBlocks
 }
 
 impl SlackMessage {
@@ -25,8 +25,6 @@ impl SlackMessage {
 
     /// Constructs a slack message from a channel id and `SlackView`.
     pub fn new(channel_id: &str, view: &impl SlackView) -> Self {
-        let mut blocks = _SlackBlocks::new();
-        view._push_blocks_into(&mut blocks);
-        Self { channel_id: channel_id.to_string(), blocks }
+        Self { channel_id: channel_id.to_string(), blocks: SlackBlocks::render(view) }
     }
 }

--- a/src/slack/ui_lib/mod.rs
+++ b/src/slack/ui_lib/mod.rs
@@ -5,3 +5,4 @@ pub mod slack_view;
 pub mod test_support;
 pub mod primitive_view;
 pub mod flat_chain_view;
+pub mod empty_view;

--- a/src/slack/ui_lib/mod.rs
+++ b/src/slack/ui_lib/mod.rs
@@ -6,3 +6,5 @@ pub mod test_support;
 pub mod primitive_view;
 pub mod flat_chain_view;
 pub mod empty_view;
+pub mod option_view;
+pub mod any_view;

--- a/src/slack/ui_lib/option_view.rs
+++ b/src/slack/ui_lib/option_view.rs
@@ -1,0 +1,38 @@
+use super::{any_view::AnySlackView, empty_view::EmptySlackView, slack_view::SlackView};
+
+impl <View: SlackView> SlackView for Option<&View> {
+    fn slack_body(&self) -> impl SlackView {
+        if let Some(view) = self {
+            return AnySlackView::erasing_ref(view.to_owned())
+        }
+        AnySlackView::erasing(EmptySlackView)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::slack::ui_lib::{block_kit_views::{SlackDivider, _SlackDivider}, slack_view::SlackView, test_support::assert_blocks_json};
+    use super::*;
+
+    struct TestView<Base: SlackView> {
+        child: Option<Base>
+    }
+
+    impl <Base: SlackView> SlackView for TestView<Base> {
+        fn slack_body(&self) -> impl SlackView {
+            self.child.as_ref()
+        }
+    }
+
+    #[test]
+    fn includes_block_when_value_present() {
+        let view = TestView { child: Some(SlackDivider) };
+        assert_blocks_json(&view, r#"[{"type":"divider"}]"#)
+    }
+
+    #[test]
+    fn excluded_block_when_value_present() {
+        let view = TestView::<_SlackDivider> { child: None };
+        assert_blocks_json(&view, r#"[]"#)
+    }
+}

--- a/src/slack/ui_lib/primitive_view.rs
+++ b/src/slack/ui_lib/primitive_view.rs
@@ -3,12 +3,12 @@ use serde_json::json;
 
 use super::{blocks::_SlackBlocks, slack_view::SlackView};
 
-#[derive(Debug)]
-pub(super) struct PrimitiveView {
+#[derive(Debug, Clone)]
+pub struct _PrimitiveView {
     json: Option<serde_json::Value>
 }
 
-impl PrimitiveView {
+impl _PrimitiveView {
     pub(super) fn new(view: &(impl SlackView + Serialize)) -> Self {
         Self { json: Some(json!(view)) }
     }
@@ -18,19 +18,23 @@ impl PrimitiveView {
     }
 }
 
-impl PrimitiveView {
+impl _PrimitiveView {
     pub(super) fn json_value(&self) -> Option<&serde_json::Value> {
         self.json.as_ref()
     }
 }
 
-impl SlackView for PrimitiveView {
+impl SlackView for _PrimitiveView {
     fn _push_blocks_into(&self, slack_blocks: &mut _SlackBlocks) {
         slack_blocks.push_primitive_view(self)
     }
 
+    fn _as_primitive_view(&self) -> Option<_PrimitiveView> {
+        Some(self.clone())
+    }
+
     #[allow(refining_impl_trait)]
-    fn slack_body(&self) -> PrimitiveView {
+    fn slack_body(&self) -> _PrimitiveView {
         panic!("Do not directly call slack_body on views, as a view may not have a body due to it being a primitive view.")
     }
 }

--- a/src/slack/ui_lib/slack_view.rs
+++ b/src/slack/ui_lib/slack_view.rs
@@ -1,10 +1,10 @@
-use super::{blocks::_SlackBlocks, flat_chain_view::_FlatChainSlackView};
+use super::{blocks::_SlackBlocks, flat_chain_view::_FlatChainSlackView, primitive_view::_PrimitiveView};
 
 /// A trait for implementing a slack view.
 ///
 /// Slack views are composed of blocks that are serialized to JSON. Views are implemented using
 /// the `slack_body` method, where they must return another `SlackView`.
-pub trait SlackView: Sized {
+pub trait SlackView {
     /// The content of this view.
     fn slack_body(&self) -> impl SlackView;
 
@@ -12,14 +12,25 @@ pub trait SlackView: Sized {
     ///
     /// `other` will be flattened when serialized into a slack message, so it is safe to call
     /// `flat_chain_block` inside the `slack_body` of `other` without incurring uneccessary nesting.
-    fn flat_chain_block<Other: SlackView + 'static>(
+    fn flat_chain_block<Other: SlackView>(
         self,
         other: Other
-    ) -> _FlatChainSlackView<Self, Other> where Self: 'static {
+    ) -> _FlatChainSlackView<Self, Other> where Self: Sized {
         _FlatChainSlackView::new(self, other)
     }
 
-    fn _push_blocks_into(&self, slack_blocks: &mut _SlackBlocks) {
+    fn _push_blocks_into(&self, slack_blocks: &mut _SlackBlocks) where Self: Sized {
         slack_blocks.push_view(self)
     }
+
+    fn _as_primitive_view(&self) -> Option<_PrimitiveView> {
+        None
+    }
+}
+
+pub(super) fn find_primitive_view(view: &impl SlackView) -> _PrimitiveView {
+    if let Some(view) = view._as_primitive_view() {
+        return view
+    }
+    find_primitive_view(&view.slack_body())
 }

--- a/src/slack/ui_lib/test_support.rs
+++ b/src/slack/ui_lib/test_support.rs
@@ -1,10 +1,80 @@
+use serde::Serialize;
+
 use super::slack_view::SlackView;
 use super::message::SlackMessage;
+use std::path::Path;
+use std::{fs::File, io::Write};
+use std::io::Read;
+use super::blocks::SlackBlocks;
 
+/// Asserts the json rendered by a slack view.
 #[cfg(test)]
 pub fn assert_blocks_json(view: &impl SlackView, json: &str) {
     let message = SlackMessage::for_testing(view);
     let expected_json = format!("{{\"channel\":\"__TEST__\",\"blocks\":{}}}", json);
     let json = serde_json::to_string(&message).unwrap();
     assert_eq!(json, expected_json)
+}
+
+#[derive(Debug, Serialize)]
+struct BlockKitBuilderCompatibleBlocks {
+    blocks: SlackBlocks
+}
+
+/// Asserts a snapshot of a `SlackView`.
+///
+/// This function is useful for testing and iterating on the UI of complex `SlackView`s. This
+/// assertion writes the output of the view to the `slack-snapshots` directory, and each snapshot
+/// can be copied and pasted directly into the
+/// [Block Kit Builder UI](https://app.slack.com/block-kit-builder/T01BFE465AN#%7B%22blocks%22:%5B%7B%22text%22:%7B%22text%22:%22I%20am%20a%20test%20view!%22,%22type%22:%22mrkdwn%22%7D,%22type%22:%22section%22%7D%5D%7D]).
+///
+/// `is_recording` is a parameter to update a snapshot when it has changed. When the value is true,
+/// the current snapshot will be overidden by the new snapshot, and the test will pass. When the
+/// value is false, the new snapshot will be asserted against the old snapshot. The new
+/// snapshot will not be written to `slack-snapshots`, but rather the gitignored
+/// `slack-snapshots-diffs` directory. This directory is useful for comparing snapshots when a test
+/// failure occurs.
+#[cfg(test)]
+pub fn assert_slack_view_snapshot(
+    name: &str,
+    view: &impl SlackView,
+    is_recording: bool
+) {
+    let raw_path = format!("./slack-snapshots/{}.json", name);
+    let path = Path::new(&raw_path);
+    let is_recording = is_recording || !path.exists();
+    let blocks = BlockKitBuilderCompatibleBlocks { blocks: SlackBlocks::render(view) };
+    let blocks_json = serde_json::to_string(&blocks).unwrap();
+    if is_recording {
+        let mut file = File::create(path).unwrap();
+        _ = file.write(blocks_json.as_bytes());
+    } else {
+        let diff_path = format!("./slack-snapshot-diffs/{}.json", name);
+        let mut file = File::create(&diff_path).unwrap();
+        _ = file.write(blocks_json.as_bytes());
+        file = File::open(path).unwrap();
+        let mut snapshot_json = String::new();
+        _ = file.read_to_string(&mut snapshot_json);
+        assert_eq!(blocks_json, snapshot_json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::slack::ui_lib::{block_kit_views::SlackSection, slack_view::SlackView};
+
+    use super::assert_slack_view_snapshot;
+
+    struct SomeView;
+
+    impl SlackView for SomeView {
+        fn slack_body(&self) -> impl SlackView {
+            SlackSection::from_markdown("I am a test view")
+        }
+    }
+
+    #[test]
+    fn record_snapshot() {
+        assert_slack_view_snapshot("test-snapshot", &SomeView, false)
+    }
 }

--- a/src/slack/ui_lib/test_support.rs
+++ b/src/slack/ui_lib/test_support.rs
@@ -26,7 +26,7 @@ struct BlockKitBuilderCompatibleBlocks {
 /// This function is useful for testing and iterating on the UI of complex `SlackView`s. This
 /// assertion writes the output of the view to the `slack-snapshots` directory, and each snapshot
 /// can be copied and pasted directly into the
-/// [Block Kit Builder UI](https://app.slack.com/block-kit-builder/T01BFE465AN#%7B%22blocks%22:%5B%7B%22text%22:%7B%22text%22:%22I%20am%20a%20test%20view!%22,%22type%22:%22mrkdwn%22%7D,%22type%22:%22section%22%7D%5D%7D]).
+/// [Block Kit Builder UI](https://app.slack.com/block-kit-builder).
 ///
 /// `is_recording` is a parameter to update a snapshot when it has changed. When the value is true,
 /// the current snapshot will be overidden by the new snapshot, and the test will pass. When the


### PR DESCRIPTION
- Adds an `EmptySlackView` struct for placeholder views.
- Adds an `AnySlackView` to aid in allowing conditional rendering.
- Adds a public `SlackBlocks` type to make a generic public interface for rendering.
- Adds a tool for snapshot testing complex slack views like the ones returned from operations, see the doc comment for more details.