### PR TITLE
Slack: Fix Parsing of Request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /FitnessProjectTest
 /slack-snapshot-diffs
 *.sqlite
+.cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-test"
 version = "15.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,9 +920,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1346,6 +1368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.1+3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1384,7 @@ checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1635,6 +1667,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "axum-extra",
  "axum-test",
  "bcrypt",
  "chrono",
@@ -1644,6 +1677,7 @@ dependencies = [
  "log",
  "nanoid",
  "once_cell",
+ "openssl",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ tokio = { version = "1.38.0", features = [
     "sync",
 ] }
 tower = "0.4.13"
+openssl = { version = "0.10", features = ["vendored"] }
+axum-extra = "0.9.3"
 
 [dev-dependencies]
 axum-test = "15.3.0"

--- a/setup.sh
+++ b/setup.sh
@@ -35,8 +35,6 @@ if [ -z "${!GITHUB_API_KEY}" ]; then
         git_ssl_keyname="roswaal-$(generate_uuid_v4)"
         echo "$git_ssl_keyname"
 
-        echo "Host github.com\nUser roswaaltifbot\nAddKeysToAgent yes\nUseKeychain yes\nIdentityFile ~/.ssh/id_rsa" > "$HOME/.ssh/config"
-
         curl -L \
         -X POST \
         -H "Accept: application/vnd.github+json" \

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,15 +1,44 @@
 use std::sync::Arc;
 
-use axum::{extract::Query, http::StatusCode, middleware::from_fn, response::IntoResponse, routing::post, serve, Json, Router};
+use anyhow::Error;
+use axum::Form;
+use axum::{
+    extract::Query, http::StatusCode, middleware::from_fn, response::IntoResponse, routing::post,
+    serve, Json, Router,
+};
 #[cfg(test)]
 use axum_test::TestServer;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
-use anyhow::Error;
 
-use crate::{git::branch_name::RoswaalOwnedGitBranchName, operations::{add_locations::AddLocationsStatus, add_tests::AddTestsStatus, close_branch::CloseBranchStatus, load_all_locations::LoadAllLocationsStatus, merge_branch::MergeBranchStatus, remove_tests::RemoveTestsStatus, save_progress::save_test_progress, search_tests::SearchTestsStatus}, slack::{add_locations_view::AddLocationsView, add_tests_view::AddTestsView, command::RoswaalSlackCommand, handler::{handle_slack_request, RoswaalSlackHandler, RoswaalSlackRequest}, locations_list_view::LocationsListView, message::SlackSendMessage, remove_tests_view::RemoveTestsView, search_tests_view::SearchTestsView, ui_lib::slack_view::SlackView}, tests_data::progress::RoswaalTestProgress, utils::sqlite::RoswaalSqlite};
+use crate::slack::ui_lib::blocks::SlackBlocks;
+use crate::{
+    git::branch_name::RoswaalOwnedGitBranchName,
+    operations::{
+        add_locations::AddLocationsStatus, add_tests::AddTestsStatus,
+        close_branch::CloseBranchStatus, load_all_locations::LoadAllLocationsStatus,
+        merge_branch::MergeBranchStatus, remove_tests::RemoveTestsStatus,
+        save_progress::save_test_progress, search_tests::SearchTestsStatus,
+    },
+    slack::{
+        add_locations_view::AddLocationsView,
+        add_tests_view::AddTestsView,
+        command::RoswaalSlackCommand,
+        handler::{handle_slack_request, RoswaalSlackHandler, RoswaalSlackRequest},
+        locations_list_view::LocationsListView,
+        message::SlackSendMessage,
+        remove_tests_view::RemoveTestsView,
+        search_tests_view::SearchTestsView,
+        ui_lib::slack_view::SlackView,
+    },
+    tests_data::progress::RoswaalTestProgress,
+    utils::sqlite::RoswaalSqlite,
+};
 
-use super::{password::check_password_middleware, response_result::ResponseResult, server_environment::ServerEnvironment};
+use super::{
+    password::check_password_middleware, response_result::ResponseResult,
+    server_environment::ServerEnvironment,
+};
 
 /// Runs this tool as an http server using the specified `ServerEnvironment`.
 pub async fn run_http_server(environment: Arc<ServerEnvironment>) -> anyhow::Result<()> {
@@ -19,144 +48,153 @@ pub async fn run_http_server(environment: Arc<ServerEnvironment>) -> anyhow::Res
 }
 
 fn roswaal_server(environment: Arc<ServerEnvironment>) -> Router<()> {
-    let slack_handler = Arc::new(HTTPSlackHandler { environment: environment.clone() });
+    let slack_handler = Arc::new(HTTPSlackHandler {
+        environment: environment.clone(),
+    });
     let messenger = environment.slack_messenger();
     let password = environment.password();
-    let password_protection = from_fn(
-        move |req, next| check_password_middleware(req, next, password.clone())
-    );
+    let password_protection =
+        from_fn(move |req, next| check_password_middleware(req, next, password.clone()));
     let sqlite_close = environment.sqlite();
     let sqlite_progress = environment.sqlite();
     let sqlite_merge = environment.sqlite();
     Router::new()
-        .route("/merge", post(move |query| post_merge_branch(query, sqlite_merge)))
-        .route("/close", post(move |query| post_close_branch(query, sqlite_close)))
-        .route("/progress", post(move |body| post_progess(body, sqlite_progress)))
+        .route(
+            "/merge",
+            post(move |query| post_merge_branch(query, sqlite_merge)),
+        )
+        .route(
+            "/close",
+            post(move |query| post_close_branch(query, sqlite_close)),
+        )
+        .route(
+            "/progress",
+            post(move |body| post_progess(body, sqlite_progress)),
+        )
         .route_layer(password_protection)
         .route(
             "/slack",
-            post(move |body| post_slack_request(body, slack_handler, messenger))
+            post(move |body| post_slack_request(body, slack_handler, messenger)),
         )
 }
 
 #[derive(Debug, Deserialize)]
 struct ProgressUpload {
-    results: Vec<RoswaalTestProgress>
+    results: Vec<RoswaalTestProgress>,
 }
 
 async fn post_progess(
     Json(upload): Json<ProgressUpload>,
-    sqlite: Arc<RoswaalSqlite>
+    sqlite: Arc<RoswaalSqlite>,
 ) -> impl IntoResponse {
-    let result = save_test_progress(
-        &upload.results,
-        sqlite.as_ref()
-    )
-    .await
-    .map(|_| StatusCode::NO_CONTENT);
+    let result = save_test_progress(&upload.results, sqlite.as_ref())
+        .await
+        .map(|_| StatusCode::NO_CONTENT);
     ResponseResult::new(result)
 }
 
 #[derive(Debug, Deserialize)]
 struct BranchQueryParameters {
-    branch: RoswaalOwnedGitBranchName
+    branch: RoswaalOwnedGitBranchName,
 }
 
 async fn post_merge_branch(
     Query(query): Query<BranchQueryParameters>,
-    sqlite: Arc<RoswaalSqlite>
+    sqlite: Arc<RoswaalSqlite>,
 ) -> impl IntoResponse {
-    let result = MergeBranchStatus::from_merging_branch_with_name(
-        &query.branch,
-        sqlite.as_ref()
-    )
-    .await
-    .map(|s| {
-        match s {
+    let result = MergeBranchStatus::from_merging_branch_with_name(&query.branch, sqlite.as_ref())
+        .await
+        .map(|s| match s {
             MergeBranchStatus::Merged(_) => StatusCode::NO_CONTENT,
-            MergeBranchStatus::UnknownBranchKind(_) => StatusCode::OK,
-        }
-    });
+            MergeBranchStatus::UnknownBranchKind(_) => StatusCode::BAD_REQUEST,
+        });
     ResponseResult::new(result)
 }
 
 async fn post_close_branch(
     Query(query): Query<BranchQueryParameters>,
-    sqlite: Arc<RoswaalSqlite>
+    sqlite: Arc<RoswaalSqlite>,
 ) -> impl IntoResponse {
-    let result = CloseBranchStatus::from_closing_branch(
-        &query.branch,
-        sqlite.as_ref()
-    )
-    .await
-    .map(|s| {
-        match s {
+    let result = CloseBranchStatus::from_closing_branch(&query.branch, sqlite.as_ref())
+        .await
+        .map(|s| match s {
             CloseBranchStatus::Closed(_) => StatusCode::NO_CONTENT,
-            CloseBranchStatus::UnknownBranchKind(_) => StatusCode::OK,
-        }
-    });
+            CloseBranchStatus::UnknownBranchKind(_) => StatusCode::BAD_REQUEST,
+        });
     ResponseResult::new(result)
 }
 
+#[derive(Serialize)]
+struct SlackResponse {
+    blocks: SlackBlocks,
+}
+
 async fn post_slack_request(
-    Json(request): Json<RoswaalSlackRequest>,
+    Form(request): Form<RoswaalSlackRequest>,
     slack_handler: Arc<HTTPSlackHandler>,
-    messenger: Arc<impl SlackSendMessage + Send + Sync + 'static>
+    messenger: Arc<impl SlackSendMessage + Send + Sync + 'static>,
 ) -> impl IntoResponse {
-    Json(handle_slack_request(slack_handler, request, messenger).await)
+    Json(SlackResponse {
+        blocks: handle_slack_request(slack_handler, request, messenger).await,
+    })
 }
 
 struct HTTPSlackHandler {
-    environment: Arc<ServerEnvironment>
+    environment: Arc<ServerEnvironment>,
 }
 
 impl RoswaalSlackHandler for HTTPSlackHandler {
     async fn handle_command(
         &self,
         command: &RoswaalSlackCommand,
-        command_text: &str
+        command_text: &str,
     ) -> Result<impl SlackView, Error> {
         match command {
             RoswaalSlackCommand::ViewTests => {
                 let status = SearchTestsStatus::from_searching_tests(
                     command_text,
-                    self.environment.sqlite().as_ref()
-                ).await?;
+                    self.environment.sqlite().as_ref(),
+                )
+                .await?;
                 Ok(SearchTestsView::new(status).erase_to_any_view())
-            },
+            }
             RoswaalSlackCommand::AddTests => {
                 let status = AddTestsStatus::from_adding_tests(
                     command_text,
                     self.environment.sqlite().as_ref(),
                     self.environment.github_pull_request_open(),
-                    self.environment.git_repository()
-                ).await?;
+                    self.environment.git_repository(),
+                )
+                .await?;
                 Ok(AddTestsView::new(status).erase_to_any_view())
-            },
+            }
             RoswaalSlackCommand::RemoveTests => {
                 let status = RemoveTestsStatus::from_removing_tests(
                     command_text,
                     self.environment.sqlite().as_ref(),
                     self.environment.git_repository(),
                     self.environment.github_pull_request_open(),
-                ).await?;
+                )
+                .await?;
                 Ok(RemoveTestsView::new(status).erase_to_any_view())
-            },
+            }
             RoswaalSlackCommand::ViewLocations => {
                 let status = LoadAllLocationsStatus::from_stored_locations(
-                    self.environment.sqlite().as_ref()
-                ).await?;
+                    self.environment.sqlite().as_ref(),
+                )
+                .await?;
                 Ok(LocationsListView::new(status).erase_to_any_view())
-            },
+            }
             RoswaalSlackCommand::AddLocations => {
                 let status = AddLocationsStatus::from_adding_locations(
                     command_text,
                     self.environment.git_repository(),
                     self.environment.sqlite().as_ref(),
-                    self.environment.github_pull_request_open()
-                ).await?;
+                    self.environment.github_pull_request_open(),
+                )
+                .await?;
                 Ok(AddLocationsView::new(status).erase_to_any_view())
-            },
+            }
         }
     }
 }
@@ -171,7 +209,10 @@ mod tests {
     use sqlx::{prelude::FromRow, query_as, Sqlite};
     use tokio::{fs::remove_file, time::sleep};
 
-    use crate::{git::branch_name::RoswaalOwnedGitBranchName, http::password::DEV_RAW_ENDPOINT_PASSWORD, with_transaction};
+    use crate::{
+        git::branch_name::RoswaalOwnedGitBranchName, http::password::DEV_RAW_ENDPOINT_PASSWORD,
+        with_transaction,
+    };
 
     use super::*;
 
@@ -180,8 +221,10 @@ mod tests {
 
     #[tokio::test]
     async fn add_and_merge_report_progress_tests() {
+        remove_file("./roswaal-dev.sqlite").await.unwrap();
         let app = test_app().await;
-        app.add_tests("\
+        app.add_tests(
+            "\
 ```
 New Test: Some Test
 Step A: This is a test
@@ -191,11 +234,13 @@ Requirement B: Merge the test into the tool
 Step C: Progress Update
 Requirement C: Update the progress on the test
 ```
-").await;
+",
+        )
+        .await;
         let branch_name = app.most_recent_branch_name().await.unwrap();
         app.merge_test(&branch_name).await;
-        let resp = app.upload_progress(
-            &json!({
+        let resp = app
+            .upload_progress(&json!({
                 "results": [
                     {
                         "testName": "Some Test",
@@ -206,41 +251,41 @@ Requirement C: Update the progress on the test
                         }
                     }
                 ]
-            })
-        )
-        .await;
+            }))
+            .await;
         resp.assert_status(StatusCode::NO_CONTENT)
     }
 
     struct TestApp {
         server: TestServer,
-        environment: Arc<ServerEnvironment>
+        environment: Arc<ServerEnvironment>,
     }
 
     impl TestApp {
         async fn add_tests(&self, tests_str: &str) {
-            self.server.post("/slack")
-                .json(&json!({
-                    "command": "/add-tests",
-                    "text": tests_str,
-                    "channel_id": ACCEPTANCE_TEST_CHANNEL_ID,
-                    "response_url": SLACK_RESPONSE_URL
-                }))
-                .await;
+            let form_data = RoswaalSlackRequest::new(
+                ACCEPTANCE_TEST_CHANNEL_ID.to_string(),
+                tests_str.to_string(),
+                RoswaalSlackCommand::AddTests,
+                SLACK_RESPONSE_URL.to_string(),
+            );
+            self.server.post("/slack").form(&form_data).await;
             // NB: The request will respond immediately with a "pending" message, we'll need to
             // manually wait for the actual work of the request to finish.
             sleep(Duration::from_millis(10_000)).await
         }
 
         async fn merge_test(&self, branch: &RoswaalOwnedGitBranchName) {
-            self.server.post("/merge")
+            self.server
+                .post("/merge")
                 .add_query_param("password", DEV_RAW_ENDPOINT_PASSWORD)
                 .add_query_param("branch", branch)
                 .await;
         }
 
         async fn upload_progress(&self, value: &Value) -> TestResponse {
-            self.server.post("/progress")
+            self.server
+                .post("/progress")
                 .add_query_param("password", DEV_RAW_ENDPOINT_PASSWORD)
                 .json(value)
                 .await
@@ -251,7 +296,7 @@ Requirement C: Update the progress on the test
             let mut transaction = sqlite.transaction().await?;
             with_transaction!(transaction, async {
                 let branch_name = query_as::<Sqlite, SqliteBranchName>(
-                    "SELECT unmerged_branch_name FROM Tests ORDER BY creation_date DESC"
+                    "SELECT unmerged_branch_name FROM Tests ORDER BY creation_date DESC",
                 )
                 .fetch_one(transaction.connection())
                 .await?;
@@ -262,7 +307,7 @@ Requirement C: Update the progress on the test
 
     #[derive(Debug, FromRow)]
     struct SqliteBranchName {
-        unmerged_branch_name: RoswaalOwnedGitBranchName
+        unmerged_branch_name: RoswaalOwnedGitBranchName,
     }
 
     async fn test_app() -> TestApp {
@@ -270,7 +315,7 @@ Requirement C: Update the progress on the test
         let environment = Arc::new(ServerEnvironment::dev().await.unwrap());
         TestApp {
             server: TestServer::new(roswaal_server(environment.clone())).unwrap(),
-            environment
+            environment,
         }
     }
 }

--- a/src/slack/command.rs
+++ b/src/slack/command.rs
@@ -1,21 +1,24 @@
+use serde::{
+    de::{Unexpected, Visitor},
+    Deserialize, Serialize,
+};
 use std::str::FromStr;
-use serde::{de::{Unexpected, Visitor}, Deserialize};
 use strum::IntoEnumIterator;
-use strum_macros::{EnumIter, EnumString, IntoStaticStr};
+use strum_macros::{Display, EnumIter, EnumString, IntoStaticStr};
 
 /// The slack slash commands that this tool must respond to.
-#[derive(Debug, PartialEq, Eq, EnumString, EnumIter, IntoStaticStr, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, EnumString, EnumIter, IntoStaticStr, Display, Clone, Copy)]
 pub enum RoswaalSlackCommand {
-    #[strum(serialize="/view-tests")]
+    #[strum(serialize = "/view-tests")]
     ViewTests,
-    #[strum(serialize="/add-tests")]
+    #[strum(serialize = "/add-tests")]
     AddTests,
-    #[strum(serialize="/remove-tests")]
+    #[strum(serialize = "/remove-tests")]
     RemoveTests,
-    #[strum(serialize="/view-locations")]
+    #[strum(serialize = "/view-locations")]
     ViewLocations,
-    #[strum(serialize="/add-locations")]
-    AddLocations
+    #[strum(serialize = "/add-locations")]
+    AddLocations,
 }
 
 impl RoswaalSlackCommand {
@@ -27,28 +30,45 @@ impl RoswaalSlackCommand {
     pub fn is_long_running(&self) -> bool {
         match self {
             Self::AddTests | Self::AddLocations | Self::RemoveTests => true,
-            _ => false
+            _ => false,
         }
     }
 }
 
-impl <'d> Deserialize<'d> for RoswaalSlackCommand {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'d> {
+impl Serialize for RoswaalSlackCommand {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'d> Deserialize<'d> for RoswaalSlackCommand {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'d>,
+    {
         deserializer.deserialize_str(RoswaalSlackCommandVistor)
     }
 }
 
 struct RoswaalSlackCommandVistor;
 
-impl <'de> Visitor<'de> for RoswaalSlackCommandVistor {
+impl<'de> Visitor<'de> for RoswaalSlackCommandVistor {
     type Value = RoswaalSlackCommand;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let commands = RoswaalSlackCommand::iter().map(|c| c.into()).collect::<Vec<&str>>();
+        let commands = RoswaalSlackCommand::iter()
+            .map(|c| c.into())
+            .collect::<Vec<&str>>();
         formatter.write_str(&format!("Any of {}.", commands.join(", ")))
     }
 
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
         RoswaalSlackCommand::from_str(v)
             .map_err(|_| serde::de::Error::invalid_value(Unexpected::Str(v), &self))
     }
@@ -60,13 +80,18 @@ mod tests {
 
     #[derive(Debug, PartialEq, Eq, Deserialize)]
     struct Container {
-        command: RoswaalSlackCommand
+        command: RoswaalSlackCommand,
     }
 
     #[test]
     fn deserialize() {
         let json = r#"{"command": "/view-tests"}"#;
         let container = serde_json::from_str::<Container>(json).unwrap();
-        assert_eq!(container, Container { command: RoswaalSlackCommand::ViewTests })
+        assert_eq!(
+            container,
+            Container {
+                command: RoswaalSlackCommand::ViewTests
+            }
+        )
     }
 }


### PR DESCRIPTION
My foolish self did not read the slack documentation and assumed that it sent a JSON body when sending slash commands. So I made sure that I parsed it as a URL encoded body instead.

Additonally, I also updated the parsing for extracting test cases out of a string. There no longer needs to be new-lines after the ```.

Lastly, I reinstalled my rust toolchain using the official method rather than through homebrew. I had to do this to get cross compiling to work, but it started applying autoformatting everywhere as a consequence. If this is the "rustacian" approved formatting style, then I push another PR to update the entire codebase soon. For now, there is a bit of an extra diff that is just formatting.