### PR TITLE
Remove .cargo from gitignore

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "x86_64-unknown-linux-gnu-gcc"

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /FitnessProjectTest
 /slack-snapshot-diffs
 *.sqlite
-.cargo


### PR DESCRIPTION
This is needed for cross-compiling.