### PR TITLE
Extract MessageView

### DIFF
--- a/src/slack/handler.rs
+++ b/src/slack/handler.rs
@@ -4,6 +4,7 @@ use super::{
     command::RoswaalSlackCommand,
     error_view::ErrorView,
     message::{SlackMessage, SlackSendMessage},
+    message_view::MessageView,
     pending_view::PendingView,
     ui_lib::{
         blocks::SlackBlocks,
@@ -72,7 +73,9 @@ pub async fn handle_slack_request(
         });
         render_slack_view(&PendingView)
     } else {
-        render_slack_view(&view_for_request(handler.as_ref(), &request).await)
+        render_slack_view(&MessageView::new(
+            &view_for_request(handler.as_ref(), &request).await,
+        ))
     }
 }
 

--- a/src/slack/message_view.rs
+++ b/src/slack/message_view.rs
@@ -1,0 +1,27 @@
+use crate::utils::env::RoswaalEnvironement;
+
+use super::ui_lib::{block_kit_views::SlackSection, if_view::If, slack_view::SlackView};
+
+pub struct MessageView<'v, Base: SlackView> {
+    base: &'v Base,
+}
+
+impl<'v, Base: SlackView> MessageView<'v, Base> {
+    pub fn new(base: &'v Base) -> Self {
+        Self { base }
+    }
+}
+
+impl<'v, Base: SlackView> SlackView for MessageView<'v, Base> {
+    fn slack_body(&self) -> impl SlackView {
+        If::is_true(
+            RoswaalEnvironement::current() == RoswaalEnvironement::Dev,
+            || {
+                SlackSection::from_markdown(
+                    "_This message was sent for development purposeeeeeeeeeees. Please Ignoooooooore!_",
+                )
+            },
+        )
+        .flat_chain_block_ref(self.base)
+    }
+}

--- a/src/slack/mod.rs
+++ b/src/slack/mod.rs
@@ -1,18 +1,19 @@
-pub mod ui_lib;
-pub mod merge_conflict_view;
-pub mod users;
-pub mod pr_open_fail_view;
-pub mod warn_undeleted_branch_view;
 pub mod add_locations_view;
-pub mod locations_list_view;
-#[cfg(test)]
-pub mod test_support;
-pub mod remove_tests_view;
 pub mod add_tests_view;
-pub mod search_tests_view;
 pub mod branch_name_view;
 pub mod command;
-pub mod handler;
-pub mod message;
-pub mod pending_view;
 pub mod error_view;
+pub mod handler;
+pub mod locations_list_view;
+pub mod merge_conflict_view;
+pub mod message;
+pub mod message_view;
+pub mod pending_view;
+pub mod pr_open_fail_view;
+pub mod remove_tests_view;
+pub mod search_tests_view;
+#[cfg(test)]
+pub mod test_support;
+pub mod ui_lib;
+pub mod users;
+pub mod warn_undeleted_branch_view;


### PR DESCRIPTION
Makes the `MessageView` a public view so that it can be used when returning normally from a slack handler.